### PR TITLE
Add the ability to pull in docs from `valkey-doc`

### DIFF
--- a/.github/workflows/deply.yml
+++ b/.github/workflows/deply.yml
@@ -27,6 +27,7 @@ jobs:
           mkdir _data/commands _includes/commands
           ln -s $(pwd)/_submodules/valkey/src/commands $(pwd)/_data/commands/latest
           ln -s $(pwd)/_submodules/valkey-doc/commands $(pwd)/_includes/commands/latest
+          ln -s $(pwd)/_submodules/valkey-doc/docs $(pwd)/_includes/docs
       - name: Setup Ruby
         uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 .DS_Store
 /_data/commands/
 /_includes/commands/
+/_includes/docs/

--- a/_includes/docs
+++ b/_includes/docs
@@ -1,0 +1,1 @@
+../_submodules/valkey-doc/docs/

--- a/_layouts/doc-import.html
+++ b/_layouts/doc-import.html
@@ -1,0 +1,29 @@
+---
+layout: default
+---
+{%- assign  primary_title = page.primary_title -%}
+{%- comment -%}
+    This template pulls in the file from `source` in the front matter.
+
+    It detects if the script starts with front matter (delimited by `---`) by splitting and looking for the delimiter at the start of the file.
+    If the delimter is detected at the top of the file, it skips the the 3rd (zero based: 2) element and iterates over the remain sections.
+    If there delmiter is not detected (no front matter) it swallows the the whole file and markdownify's it.
+
+{%- endcomment -%}
+{%- capture md -%}{% include {{ page.source }} %}{%- endcapture -%}
+{%- assign stripped_front_matter = md | split: "---" -%}
+{%- include page_title.html -%}
+<div class="width-limiter">
+    <main class="container">
+        {%- if stripped_front_matter[0].size == 0 -%}
+            {%- for item in stripped_front_matter offset:2 -%}
+                {{ item | markdownify }}
+                {%- if forloop.last == false -%}
+                    <hr />
+                {%- endif -%}
+            {%- endfor -%}
+        {%- else -%}
+            {{ md | markdownify }}
+        {%- endif -%}
+    </main>
+</div>

--- a/docs/management/persistence.md
+++ b/docs/management/persistence.md
@@ -1,0 +1,5 @@
+---
+layout: doc-import
+primary_title: Persistence
+source: "/docs/management/persistence.md"
+---


### PR DESCRIPTION
### Description

- Adds doc import layout (see below)
- Adds example of using doc import layout for `docs/management/persistence.md`
- Adds another symbolic link to the `_includes` folder for the markdown docs from `valkey-doc` in the workflow
- Updates submodule

#### What does the `doc-import` layout do?

This allows the consumption of the existing markdown files in `valkey-doc` by stripping out the existing frontmatter (which is not relevant). Alternately, if there isn't front matter on the file (it doesn't start with `---`) it still works.

This way we can keep the concerns separated: `valkey-doc` contains content, `valkey-website` contains metadata and site specific (templates, forward, etc.) information. 
 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
