### PR TITLE
Docs stub page + 2 docs pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+---
+layout: simple
+title: Documentation
+primary_title: Documentation
+---
+
+* [Command Reference](../commands/)
+* Management
+  * [Persistence](./management/persistence/)
+  * Security
+    * [ACL](./management/security/acl/)
+* Valkey Manual
+  * [Keyspace Notifications](./manual/keyspace-notifications/)

--- a/docs/management/security/acl.md
+++ b/docs/management/security/acl.md
@@ -1,0 +1,5 @@
+---
+layout: doc-import
+primary_title: ACL
+source: "/docs/management/security/acl.md"
+---

--- a/docs/manual/keyspace-notifications.md
+++ b/docs/manual/keyspace-notifications.md
@@ -1,0 +1,5 @@
+---
+layout: doc-import
+primary_title: Keyspace Notifications
+source: /docs/manual/keyspace-notifications.md
+---


### PR DESCRIPTION
### Description

- Adds a non-dynamic docs page
- Adds ACL and  Keyspace notifications docs page metadata

#### Why non-dynamic?

Right now docs are swiss cheese as the team works through "localizing" everything to Valkey. It would be very frustrating to see nested menu after nested menu with single items on them. Once the docs are fleshed out, it would be smart to move to a dynamic display that iterates over pages.

### Issues Resolved

Related to #13 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
