### PR TITLE
adds basic downloads page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,9 +29,18 @@ defaults:
     values:
       layout: "author"
       permalink: /:collection/:name/
+-
+  scope:
+    path: ""
+    type: "releases"
+  values:
+    layout: "release"
+    permalink: download/:collection/:name
 
 collections:
   authors:
+    output: true
+  releases:
     output: true
 
 paginate: 5

--- a/_includes/release.html
+++ b/_includes/release.html
@@ -1,0 +1,8 @@
+<strong>Release Date:</strong> {{include.content.date | date: "%a, %b %d, %Y"}}<br/>
+<strong>GitHub Release:</strong> <a href="https://github.com/valkey-io/valkey/releases/tag/{{include.content.tag}}">{{include.content.tag}}</a><br />
+<strong>Docker Tags:</strong>
+<ul>
+    {% for tag in include.content.container.tags %}
+        <li><code>{{ tag }}</code></li>
+    {% endfor %}
+</ul>

--- a/_layouts/release.html
+++ b/_layouts/release.html
@@ -1,0 +1,14 @@
+---
+layout: default
+---
+{% capture primary_title %}Release: <strong>{{page.name}}</strong>{% endcapture %}
+{% assign this_release = page %}
+{% include page_title.html %}
+
+
+
+<div class="width-limiter">
+    <main class="container">
+        {% include release.html content=this_release %}
+    </main>
+</div>

--- a/_releases/v7-2-4-rc1.markdown
+++ b/_releases/v7-2-4-rc1.markdown
@@ -1,0 +1,14 @@
+---
+name: "7.2.4-rc1"
+date: 2024-04-09
+tag: "7.2.4-rc1"
+container:
+    tags:
+        - "7.2.4-rc1"
+        - "7.2.4-rc1-bookworm"
+        - "7.2.4-rc1-alpine"
+        - "7.2.4-rc1-alpine3.19"
+
+---
+
+Hello world!

--- a/download/index.html
+++ b/download/index.html
@@ -3,3 +3,6 @@ layout: simple
 primary_title: Download
 title: Download
 ---
+{% assign current_release= site.releases | first %}
+
+{% include release.html content=current_release %}


### PR DESCRIPTION
### Description

Adds a basic downloads page and release mechanism. 

#### How does this work?

- Each release gets a markdown file in `/_releases/`
- So, for `v7.2.4-rc1` there is `_releases/v7-2-4-rc1.markdown`
- The front matter of the markdown file defines the metadata regarding the release
- `/download/` is populated by the most recent `_release` file (by `date` in front matter) 
- Each release gets a stable link at `/download/releases/` So, for `v7.2.4-rc1` it will be `/download/releases/v7-2-4-rc1/`

(This only contains github tag and docker release, but can be easily expanded)
 
### Issues Resolved

Related to #13


### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
