### PR TITLE
change links to direct file vs path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ primary_title: Documentation
 
 * [Command Reference](../commands/)
 * Management
-  * [Persistence](./management/persistence/)
+  * [Persistence](/docs/management/persistence.html)
   * Security
-    * [ACL](./management/security/acl/)
+    * [ACL](/docs/management/security/acl.html)
 * Valkey Manual
-  * [Keyspace Notifications](./manual/keyspace-notifications/)
+  * [Keyspace Notifications](/docs/manual/keyspace-notifications.html)


### PR DESCRIPTION
### Description

GitHub Pages hosting doesn't have the ability to do URLs that end in `/` for individual HTML files. So, for example, 
`https://valkey-io.github.io/docs/management/persistence/` won't resolve `https://valkey-io.github.io/docs/management/persistence.html`.

 This PR changes the links on docs index to direct `.html` files instead.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
