### PR TITLE
adds _site to gitignore for transition purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ content/commands/*
 !content/commands/_index.md
 content/docs/topics/*
 !content/docs/topics/_index.md
+_site


### PR DESCRIPTION
### Description

For those transitioning from the Jekyll version to Zola, this adds the Jekyll build (`_site`) to the .gitignore file so it doesn't try to commit built files when switching between versions.

`_site` is unused in Zola.

### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
