### PR TITLE
Fixes from topic review

### DIFF
--- a/build/init-topics.sh
+++ b/build/init-topics.sh
@@ -33,7 +33,7 @@ done
 
 echo "Topic stub files created."
 
-for fname in $(find $1 -maxdepth 1  -iname "*.png" -o -iname "*.jpg" -o -iname "*.jpeg")
+for fname in $(find $1 -maxdepth 1  -iname "*.png" -o -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.gif")
 do
     base=${fname##*/}
     cp ${fname} ./content/docs/topics/${base}

--- a/config.toml
+++ b/config.toml
@@ -7,10 +7,50 @@ build_search_index = true
 [markdown]
 highlight_code = true
 
+# This is included to override any differences slugs and documentation source filenames
+[extra.slug_source_exceptions]
+"valkey-conf" = "valkey.conf"
+
 [extra]
 command_description_path = "../build-command-docs/"
 command_json_path = "../build-command-json/"
 doc_topic_path = "../build-topics/"
 
 review_list = [
+    "/docs/topics/license/",
+    "/docs/topics/admin/",
+    "/docs/topics/distlock/",
+    "/docs/topics/eval-intro/",
+    "/docs/topics/faq/",
+    "/docs/topics/functions-intro/",
+    "/docs/topics/hashes/",
+    "/docs/topics/internals-eventlib/",
+    "/docs/topics/internals-vm/",
+    "/docs/topics/internals/",
+    "/docs/topics/latency/",
+    "/docs/topics/lua-api/",
+    "/docs/topics/modules-blocking-ops/",
+    "/docs/topics/modules-intro/",
+    "/docs/topics/pipelining/",
+    "/docs/topics/programmability/",
+    "/docs/topics/protocol/",
+    "/docs/topics/pubsub/",
+    "/docs/topics/rdd/",
+    "/docs/topics/replication/",
+    "/docs/topics/security/",
+    "/docs/topics/sentinel-clients/",
+    "/docs/topics/sentinel/",
+    "/docs/topics/transactions/",
+    "/docs/topics/cluster-spec/",
+    "/docs/topics/history/"
+]
+
+publish_hold = [
+    "/docs/topics/protocol/",
+    "/docs/topics/license/",
+    "/docs/topics/internals-eventlib/",
+    "/docs/topics/internals-vm/",
+    "/docs/topics/internals/",
+    "/docs/topics/protocol/",
+    "/docs/topics/rdd/"
 ]

--- a/config.toml
+++ b/config.toml
@@ -13,4 +13,5 @@ command_json_path = "../build-command-json/"
 doc_topic_path = "../build-topics/"
 
 review_list = [
+    "/docs/topics/admin/"
 ]

--- a/config.toml
+++ b/config.toml
@@ -13,5 +13,4 @@ command_json_path = "../build-command-json/"
 doc_topic_path = "../build-topics/"
 
 review_list = [
-    "/docs/topics/admin/"
 ]

--- a/content/commands/_index.md
+++ b/content/commands/_index.md
@@ -2,4 +2,7 @@
 title = "Commands"
 template = "commands.html"
 page_template = "command-page.html"
+aliases= [
+    "/docs/topics/commands/"
+]
 +++

--- a/templates/docs-page.html
+++ b/templates/docs-page.html
@@ -33,5 +33,9 @@
 <hr />
 {% endif %}
 {%- set content_with_fixed_links = docs::fix_links(content= page_contents) -%}
-{{ content_with_fixed_links | markdown | safe }}
+{% if config.extra.publish_hold is containing(page.path) %}
+    <p><code>{{ page.path }}</code> may be available after revisions.</p>
+{% else %}
+    {{ content_with_fixed_links | markdown | safe }}
+{% endif %}
 {% endblock main_content %}

--- a/templates/macros/docs.html
+++ b/templates/macros/docs.html
@@ -1,5 +1,8 @@
 {%- macro load(slug) -%}
 {%- set topic_path = config.extra.doc_topic_path -%}
+{%- if slug in config.extra.slug_source_exceptions -%}
+    {%- set slug = config.extra.slug_source_exceptions[slug] -%}
+{%- endif -%}
 {%- set markdown_content = load_data(path= topic_path ~ "/" ~ slug ~ ".md", required= false) -%}
 {%- if markdown_content -%}{{ markdown_content }}{% endif %}
 {% endmacro load_doc %}
@@ -21,11 +24,16 @@
 
 {%- macro fix_links(content) -%}
 {{ content 
-        | regex_replace(pattern=`\]\((?P<fname>.*?)\w.png\)`, rep=`](/docs/topics/$fname.png)`) 
-        | regex_replace(pattern=`\]\(\.\./commands/(?P<fname>\w.*?)(.md)?\)`, rep=`](/commands/$fname)`) 
+        | regex_replace(pattern=`\]\(#(?P<hash>.*?\))`, rep=`](--$hash`)
+        | regex_replace(pattern=`\]\((?P<url>httpsd?:\/\/.*?\))`, rep=`](-$url`)
+        | regex_replace(pattern=`\]\(\.\./commands/(?P<fname>\w.*?)(.md)?#(?P<hash>.*?)\)`, rep=`](/commands/$fname#$hash)`) 
+        | regex_replace(pattern=`\]\(\.\./commands/(?P<fname>\w.*?)(.md)?\)`, rep=`](/commands/$fname)`)
         | regex_replace(pattern=`\]\(\.\./commands/#(?P<hash>\w.*?)\)`, rep=`](/commands/#$hash)`) 
         | regex_replace(pattern=`\]\((?P<fname>\w.*?)(.md)?#(?P<hash>.*?)\)`, rep=`](/docs/topics/$fname#$hash)`)
+        | regex_replace(pattern=`\]\((?P<fname>.*?).png\)`, rep=`](/docs/topics/$fname.png)`) 
+        | regex_replace(pattern=`\]\((?P<fname>.*?).gif\)`, rep=`](/docs/topics/$fname.gif)`) 
         | regex_replace(pattern=`\]\((?P<fname>\w.*?)(.md)?\)`, rep=`](/docs/topics/$fname)`) 
-        | regex_replace(pattern=`\]\(\/docs\/topics/http\:`, rep=`](http:`) 
-    }}
+        | regex_replace(pattern=`\]\(\-(?P<url>https?:\/\/.*?\))`, rep=`]($url`)
+        | regex_replace(pattern=`\]\(\--(?P<hash>.*?\))`, rep=`](#$hash`)
+}}
 {%- endmacro fix_links -%}

--- a/templates/macros/docs.html
+++ b/templates/macros/docs.html
@@ -21,10 +21,11 @@
 
 {%- macro fix_links(content) -%}
 {{ content 
-    | regex_replace(pattern=`\]\((?P<fname>.*?).png\)`, rep=`](/docs/topics/$fname.png)`) 
-    | regex_replace(pattern=`\]\(\.\./commands/(?P<fname>.*?).md\)`, rep=`](/commands/$fname)`) 
-    | regex_replace(pattern=`\]\(\.\./commands/#(?P<hash>.*?)\)`, rep=`](/commands/#$hash)`) 
-    | regex_replace(pattern=`\]\((?P<fname>.*?).md\)`, rep=`](/docs/topics/$fname)`) 
-    | regex_replace(pattern=`\]\((?P<fname>.*?).md#(?P<hash>.*?)\)`, rep=`](docs/topics/$fname#$hash)`) 
+        | regex_replace(pattern=`\]\((?P<fname>.*?)\w.png\)`, rep=`](/docs/topics/$fname.png)`) 
+        | regex_replace(pattern=`\]\(\.\./commands/(?P<fname>\w.*?)(.md)?\)`, rep=`](/commands/$fname)`) 
+        | regex_replace(pattern=`\]\(\.\./commands/#(?P<hash>\w.*?)\)`, rep=`](/commands/#$hash)`) 
+        | regex_replace(pattern=`\]\((?P<fname>\w.*?)(.md)?#(?P<hash>.*?)\)`, rep=`](/docs/topics/$fname#$hash)`)
+        | regex_replace(pattern=`\]\((?P<fname>\w.*?)(.md)?\)`, rep=`](/docs/topics/$fname)`) 
+        | regex_replace(pattern=`\]\(\/docs\/topics/http\:`, rep=`](http:`) 
     }}
 {%- endmacro fix_links -%}


### PR DESCRIPTION
### Description

A few issues came up while reviewing for publication. valkey-io/valkey-doc#91

1. the regex was a little greedy and would occasionally eat two markdown links in one and causing a weird edge case where two transforms occur at once. The changes in `templates/macros/docs.html` fixes resolves this.
2. The docs repo differs in structure compared to website and calling commands is tricky. This gives an alias to the command listing page to make them play nice.

**Update 05/31** (probably should have made the original PR a draft) 

- Added a few more fixes for the URL re-writer
- Add the bits to allow for suppressing pages that still exist in the docs repo but shouldn't be published (yet/ever).
- Added the specific pages that need the review warning and to be supressed



### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
