### PR TITLE
Fixes nav to be responsive on mobile screens

### DIFF
--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -25,6 +25,7 @@
 * {
   box-sizing: border-box;
 }
+
 html {
   height: 100%;
   width: 100%;
@@ -108,9 +109,16 @@ p {
   padding: 10px 0;
 
   .width-limiter {
+    display: flex;
+    gap: 2rem;
     flex-flow: row nowrap;
     justify-content: space-between;
     align-items: baseline;
+
+    @media all and (max-width: 768px) {
+        flex-flow: column;
+        align-items: center;
+    }
   }
 
   .logo {
@@ -139,19 +147,21 @@ p {
   nav {
     display: flex;
     flex-flow: row nowrap;
+    gap: 2rem;
     @include sans-serif;
     font-size: 1.5rem;
     font-weight: 400;
 
+    @media all and (max-width: 480px) {
+        gap: 1rem;
+        display: grid;
+        text-align: center;
+    }
+
     a {
       white-space: nowrap;
-      padding: 0 1rem;
       color: inherit;
       cursor: pointer;
-
-      &:last-child {
-        padding-right: 0;
-      }
 
       &:hover {
         color: #04202a;


### PR DESCRIPTION
### Description

**Fixes the Zola version, though the CSS should also work for the Jekyll version.**

The website behaves pretty well on mobile screen sizes except for the nav which breaks the site currently:

![2024-05-25 22 03 09 192 168 50 217 b148da25c89d](https://github.com/valkey-io/valkey-io.github.io/assets/166604072/4d45ef15-ad10-4037-9841-8c4c49d08583)

This PR adds some media queries to move the nav menu underneath the logo. In the event of a user having an even smaller screen, it will switch the menu to display in column format. (Not ideal but as the design of the site evolves, I imagine there'll be a niftier solution such as a burger etc etc.)

Fixed:

![2024-05-25 22 14 17 localhost 0f0e6f9d7595](https://github.com/valkey-io/valkey-io.github.io/assets/166604072/1edb8245-b125-4ffd-8818-efb1e2f688de)

![2024-05-25 22 14 43 localhost 51b2cab4420a](https://github.com/valkey-io/valkey-io.github.io/assets/166604072/8626b06d-83de-4cf8-88d6-d5c7e42aecfe)
 
### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.

