### PR TITLE
Fixes YouTube embed in /docs/topics/ldb/ breaking layout

### DIFF
--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -263,6 +263,12 @@ p {
     width: 100%;
     height: auto;
   }
+
+  .container.right-aside iframe {
+    @media all and (max-width: 768px) {
+      width: 100%;
+    }
+  }
 }
 
 .page-title {


### PR DESCRIPTION
### Description

The YouTube embed in /docs/topics/ldb/ currently breaks the layout on the page when viewed on mobile devices.

PR adds a media query to set the embed width to 100% of the available area on small screens.

![Screencast from 2024-05-29 13-55-11](https://github.com/valkey-io/valkey-io.github.io/assets/166604072/901ba01f-cc65-42c4-92cf-397f1b3022ff)

### Issues Resolved

#76 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
