### PR TITLE
corrects yaml to allow manual workflow runs from actions tab

### DIFF
--- a/.github/workflows/zola-deploy.yml
+++ b/.github/workflows/zola-deploy.yml
@@ -3,7 +3,8 @@ name: Zola on GitHub Pages
 on:
   push:
     branches: ["prod_zola"]
-    workflow_dispatch:
+  
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description

`workflow_dispatch` was at the wrong tab level. Moving this to the correct tab level will allow for manual running this from the action tab.

 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
