### PR TITLE
restores may roundup blog post

### DIFF
--- a/content/blog/2024-05-24-may-roundup.md
+++ b/content/blog/2024-05-24-may-roundup.md
@@ -1,0 +1,47 @@
++++
+title=  "What's new in Valkey for May 2024"
+date= 2024-05-24 01:01:01
+aliases= [
+    "/blog/modules/2024/05/may-roundup/"
+]
+description= "It's become clear that people want to talk about Valkey and have been publishing blog posts/articles fervently. Here you'll find a collection of all the post I'm aware of in the last few weeks."
+
+[extra]
+authors= ["kyledvs"]
+categories= "update"
++++
+
+It's become clear that people want to talk about Valkey and have been publishing blog posts/articles fervently.
+Here you'll find a collection of all the post I'm aware of in the last few weeks.
+
+## Percona
+
+The kind folks over at Percona have been on an absolutely legendary streak of posting about Valkey.
+They've done a series on data types ([Hashes](https://www.percona.com/blog/valkey-redis-the-hash-datatype/), [Sorted Sets](https://www.percona.com/blog/valkey-redis-sets-and-sorted-sets/)), [best](https://www.percona.com/blog/valkey-redis-configuration-best-practices/) and [not-so-good practices](https://www.percona.com/blog/valkey-redis-not-so-good-practices/), [getting started](https://www.percona.com/blog/hello-valkey-lets-get-started/), [replication/failover](https://www.percona.com/blog/valkey-redis-replication-and-auto-failover-with-sentinel-service/), [configurations/persistence](https://www.percona.com/blog/valkey-redis-configurations-and-persistent-setting-of-the-key-parameters/), and finally their own [Valkey packages for DEB and RPM-based distros](https://www.percona.com/blog/hello-valkey-lets-get-started/).
+
+## Fedora Magazine
+
+Yours truly wrote an article for [Fedora Magazine about using the `valkey-compat-redis` package to move to Valkey](https://fedoramagazine.org/how-to-move-from-redis-to-valkey/).
+
+## Community.aws
+
+Ricardo Ferreira put together a [walkthrough of using Valkey with Go on Docker](https://community.aws/content/2fdr6Vg8BiJS8jr8xsuQRRc0MD5/getting-started-with-valkey-using-docker-and-go).
+
+## The New Stack
+
+While Open Source Summit North America was last month, [The New Stack published a blog post about Valkey](https://thenewstack.io/valkey-a-redis-fork-with-a-future/) and accompany interview with project leaders, it's worth a watch and read.
+
+## Presentation: Digging into Valkey
+
+On the subject of Open Source Summit, the talk I gave along side Madelyn Olson, ["Digging into Valkey" was posted as a video](https://youtu.be/3G6QgwIl-xs).
+
+## Valkey Seattle IRL
+
+The [Seattle Valkey Meetup](https://www.meetup.com/seattle-valkey/) is holding a [Rust module workshop on June 5th](https://www.meetup.com/seattle-valkey/events/301177195/).
+A lot of folks will be in town for the Contributor Summit, so this meet up is bound to  be flush with Valkey experts.
+Don't miss it.
+
+## Want to add your tutorial/article/meetup/video to a future roundup?
+
+This is the first in a series of roundups on Valkey content.
+The plan is to keep an [draft pull request open on the website GitHub repo](https://github.com/valkey-io/valkey-io.github.io/issues?q=is%3Adraft+label%3Aroundup-post+) where you can contribute your own content.


### PR DESCRIPTION
### Description

The post "[What's new in Valkey for May 2024](https://github.com/valkey-io/valkey-io.github.io/blob/jekyll-version/_posts/2024-05-24-may-roundup.markdown)" didn't make it over from the transition from Jekyll to Zola. This PR restores the blog post.
 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
