### PR TITLE
adds `atom.xml` feed, simplifies authors metadata, adds description for release

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,8 @@ compile_sass = true
 
 build_search_index = true
 
+generate_feed = true
+
 [markdown]
 highlight_code = true
 

--- a/content/blog/2024-04-12-hello-world.md
+++ b/content/blog/2024-04-12-hello-world.md
@@ -5,8 +5,10 @@ aliases = [
     "/blog/update/2024/04/hello-world/"
 ]
 description= "Welcome! For the inaugural blog post on valkey.io, I’d like to recap the story so far, what to look forward to, and then describe how this blog works."
-[extra]
 authors= ["kyledvs"]
+
+[extra]
+
 categories= "update"
 +++
 

--- a/content/blog/2024-04-16-valkey-7-2-5-out.md
+++ b/content/blog/2024-04-16-valkey-7-2-5-out.md
@@ -5,9 +5,10 @@ aliases= [
     "/blog/modules/2024/05/modules-101/"
 ]
 description= "Exciting times!I'm pleased to announce that you can start using the first generally available, stable Valkey release today."
+authors= ["kyledvs"]
 
 [extra]
-authors= ["kyledvs"]
+
 categories= "update"
 +++
 

--- a/content/blog/2024-04-26-modules-101.md
+++ b/content/blog/2024-04-26-modules-101.md
@@ -5,8 +5,10 @@ aliases= [
     "/blog/update/2024/04/valkey-7-2-5-out/"
 ]
 description= "The idea of modules is to allow adding extra features (such as new commands and data types) to Valkey without making changes to the core code."
-[extra]
 authors= ["dmitrypol"]
+
+[extra]
+
 categories= "modules"
 +++
 

--- a/content/blog/2024-05-24-may-roundup.md
+++ b/content/blog/2024-05-24-may-roundup.md
@@ -5,9 +5,9 @@ aliases= [
     "/blog/modules/2024/05/may-roundup/"
 ]
 description= "It's become clear that people want to talk about Valkey and have been publishing blog posts/articles fervently. Here you'll find a collection of all the post I'm aware of in the last few weeks."
+authors= ["kyledvs"]
 
 [extra]
-authors= ["kyledvs"]
 categories= "update"
 +++
 

--- a/content/download/releases/v7-2-5.md
+++ b/content/download/releases/v7-2-5.md
@@ -33,3 +33,5 @@ extra:
                 -   arm64
                 -   x86_64
 ---
+
+Valkey 7.2.5 Release

--- a/templates/blog-page.html
+++ b/templates/blog-page.html
@@ -4,9 +4,9 @@
 <h1>{{ page.title }}</h1>
 <div class="meta">
   {{ page.date | date(format="%Y-%m-%d") }}
-  {% if page.extra and page.extra.authors %}
+  {% if page.authors %}
     &middot; 
-    {% for author in page.extra.authors %}
+    {% for author in page.authors %}
       {% set author_path = "authors/" ~ author ~ ".md" %}
       {% set author_page = get_page(path=author_path) %}
       <em>{{ author_page.title }}</em>{% if loop.last != true %},{% endif %}
@@ -28,8 +28,8 @@
 
 {% endblock main_content %}
 {% block related_content %}
-{% if page.extra and page.extra.authors %}
-  {% for author in page.extra.authors %}
+{% if page.authors %}
+  {% for author in page.authors %}
     {% set author_path = "authors/" ~ author ~ ".md" %}
     {% set author_page = get_page(path=author_path) %}
     {% include "includes/author_panel.html" %}

--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -36,6 +36,7 @@
     </title>
 
     <link rel="stylesheet" href="/css/styles.css">
+    <link rel="alternate" type="application/atom+xml" title="Atom feed" href="{{ get_url(path="atom.xml", trailing_slash=false) }}" />
 
 
     <!-- Google tag (gtag.js)


### PR DESCRIPTION
### Description

This release `atom.xml` adds a feed to valkey.io

Three things were needed & accomplished in this PR

1. `generate_feed` was set to `true`
2. The blog metadata needed to be reconfigured moving the `authors` array out from under `extra` back up to top-level of the meta data object. I had to touch all the blog posts to fix this and make a minor change the page template.
3. Add the feed auto discovery tag to the page header


To my pleasant surprise Zola was smart enough to find _any_ page with a date and add it to the feed. Since releases are technically pages with dates, they are also included in the feed, not just blog posts. I imagine this will be very useful for folks. Because releases don't really have any content, the resulting atom entry was a bit mysterious. Consequently, I added a description to the 7.2.5 release. This doesn't show up in any other rendered state except the feed.

 
### Issues Resolved

#79

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
