### PR TITLE
imports topics from valkey-doc, adds docs menu, and taxonomy for tech blog

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@ compile_sass = true
 build_search_index = true
 
 taxonomies = [
-    { name = "Technical Blog Posts", feed = true}
+    { name = "Tutorials", feed = true}
 ]
 
 [markdown]
@@ -58,3 +58,6 @@ publish_hold = [
     "/docs/topics/protocol/",
     "/docs/topics/rdd/"
 ]
+
+[extra.taxonomies.tutorials]
+heading = "Documentation"

--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,10 @@ compile_sass = true
 
 build_search_index = true
 
+taxonomies = [
+    { name = "Technical Blog Posts", feed = true}
+]
+
 [markdown]
 highlight_code = true
 

--- a/content/blog/2024-04-26-modules-101.md
+++ b/content/blog/2024-04-26-modules-101.md
@@ -5,6 +5,8 @@ aliases= [
     "/blog/update/2024/04/valkey-7-2-5-out/"
 ]
 description= "The idea of modules is to allow adding extra features (such as new commands and data types) to Valkey without making changes to the core code."
+[taxonomies]
+"Technical Blog Posts"=[ "Modules" ]
 [extra]
 authors= ["dmitrypol"]
 categories= "modules"

--- a/content/blog/2024-04-26-modules-101.md
+++ b/content/blog/2024-04-26-modules-101.md
@@ -6,7 +6,7 @@ aliases= [
 ]
 description= "The idea of modules is to allow adding extra features (such as new commands and data types) to Valkey without making changes to the core code."
 [taxonomies]
-"Technical Blog Posts"=[ "Modules" ]
+Tutorials = [ "Modules" ]
 [extra]
 authors= ["dmitrypol"]
 categories= "modules"

--- a/content/commands/_index.md
+++ b/content/commands/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Commands"
+title = "Documentation: Commands"
 template = "commands.html"
 page_template = "command-page.html"
 aliases= [

--- a/content/commands/_index.md
+++ b/content/commands/_index.md
@@ -3,6 +3,7 @@ title = "Commands"
 template = "commands.html"
 page_template = "command-page.html"
 aliases= [
-    "/docs/topics/commands/"
+    "/docs/topics/commands/",
+    "/docs/commands/"
 ]
 +++

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,9 +1,9 @@
 +++
-title = "Docs"
+title = "Documentation"
 template = "fullwidth.html"
 page_template = "docs-page.html"
 +++
 
 * [Command Reference](../commands/)
 * [Documentation by Topic](./topics/)
-* [Technical Blog Posts](/technical-blog-posts/)
+* [Tutorials](/tutorials/)

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -5,10 +5,5 @@ page_template = "docs-page.html"
 +++
 
 * [Command Reference](../commands/)
-* [All Documentation Topics](./topics/)
-* Management
-  * [Persistence](/docs/topics/persistence/)
-  * Security
-    * [ACL](/docs/topics/acl/)
-* Valkey Manual
-  * [Keyspace Notifications](/docs/topics/keyspace/)
+* [Documentation by Topic](./topics/)
+* [Technical Blog Posts](/technical-blog-posts/)

--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -530,6 +530,16 @@ pre table {
   border-collapse: collapse;
 }
 
+.index-entry {
+  border: 1px solid $line;
+  border-radius: 3px;
+  padding: 0.5em 1em;
+  margin-bottom: 0.5em;
+  a {
+    display: block;
+  }
+}
+
 .command-entry {
   border-bottom: 1px dotted $line;
   margin-top: 0.5rem;

--- a/templates/default.html
+++ b/templates/default.html
@@ -13,7 +13,14 @@
       </a>
       <nav role="navigation" aria-label="Main">
         <a role="menuitem" href="/download/">Download</a>
-        <a role="menuitem" href="/docs/">Documentation</a>
+        <div class="has-submenu">
+          <a role="menuitem" href="/docs/">Documentation</a>
+            <div class="submenu">
+              <a role="menuitem" href="/commands/">Command Reference</a>
+              <a role="menuitem" href="/docs/topics/">Documentation by Topic</a>
+              <a role="menuitem" href="/technical-blog-posts/">Technical Blog Posts</a>
+            </div>
+        </div>
         <a role="menuitem" href="/commands/">Commands</a>
         <div class="has-submenu">
           <span>Community</span>

--- a/templates/default.html
+++ b/templates/default.html
@@ -18,10 +18,9 @@
             <div class="submenu">
               <a role="menuitem" href="/commands/">Command Reference</a>
               <a role="menuitem" href="/docs/topics/">Documentation by Topic</a>
-              <a role="menuitem" href="/technical-blog-posts/">Technical Blog Posts</a>
+              <a role="menuitem" href="/tutorials/">Tutorials</a>
             </div>
         </div>
-        <a role="menuitem" href="/commands/">Commands</a>
         <div class="has-submenu">
           <span>Community</span>
             <div class="submenu">

--- a/templates/docs-page.html
+++ b/templates/docs-page.html
@@ -21,7 +21,7 @@
 
 {% block subhead_content %}
 {% if has_frontmatter and frontmatter_title %}
-<h1 class="page-title">{{ frontmatter_title }}</h1>
+<h1 class="page-title">Documentation: {{ frontmatter_title }}</h1>
 {% endif  %}
 {% endblock subhead_content %}
 

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -2,6 +2,10 @@
 
 {% import "macros/docs.html" as docs %}
 
+{% block subhead_content %}
+<h1 class="page-title">Documentation</h1>
+{% endblock subhead_content %}
+
 {% block main_content %}
 <h1>{{ section.title }}</h1>
 

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -1,12 +1,27 @@
-{% extends "fullwidth.html" %}
+{% extends "right-aside.html" %}
 
 {% import "macros/docs.html" as docs %}
 
 {% block main_content %}
+<h1>{{ section.title }}</h1>
+
+
 {% set list = [] %}
 {% if section.pages | length == 0 %}
 <strong>No docs pages found.</strong> You likely need to build the documentation pages. See "Building additional content" in README.md file.
 {% endif %}
+
+{% set docs_file_contents = docs::load(slug= "index") %}
+{% set frontmatter = docs::extract_frontmatter(content= docs_file_contents) %}
+{% set page_contents = docs::extract_markdown(content= docs_file_contents) %}
+{%- set content_with_fixed_links = docs::fix_links(content= page_contents) -%}
+
+
+{{ content_with_fixed_links  | markdown | safe }}
+{% endblock main_content %}
+
+{% block related_content %}
+<h2>Alphabetical Index</h2>
 {% for page in section.pages %}
     {% set docs_file_contents = docs::load(slug= page.slug) %}
     {% set frontmatter = docs::extract_frontmatter(content= docs_file_contents) %}
@@ -26,7 +41,9 @@
     {% set topic_list = load_data(literal= "[" ~ joined_list ~ "]", format="json") | sort(attribute="title") %} 
     
     {% for topic in topic_list %}
-        <a href="{{ topic.path }}">{{ topic.title }}</a> {{ topic.description | safe }} <br />
+        <div class="index-entry">
+            <a href="{{ topic.path }}">{{ topic.title }}</a> {{ topic.description | safe }} <br />
+        </div>
     {% endfor %}
 
-{% endblock main_content %}
+{% endblock related_content %}

--- a/templates/taxonomy.html
+++ b/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% extends "right-aside.html" %}
+
+
+{% block subhead_content %}
+{% if config.extra.taxonomies and config.extra.taxonomies[taxonomy.slug] and config.extra.taxonomies[taxonomy.slug].heading %}
+<h1 class="page-title">{{ config.extra.taxonomies[taxonomy.slug].heading }}</h1>
+{% endif  %}
+{% endblock subhead_content %}
+

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -1,0 +1,17 @@
+{% extends "right-aside.html" %}
+
+{% block main_content %}
+<h1>{{ taxonomy.name }}</h1>
+<ul>
+    {% for term in terms %}
+        <li><a href="{{ term.path }}">{{ term.name }}</a>
+            <ul>
+                {% for page in term.pages %}
+                    <li><a href="{{ page.path }}">{{ page.title }}</a></li>
+                {% endfor %}
+            </ul>
+        </li>
+    {% endfor %}
+</ul>
+
+{% endblock main_content %}

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -1,4 +1,4 @@
-{% extends "right-aside.html" %}
+{% extends "taxonomy.html" %}
 
 {% block main_content %}
 <h1>{{ taxonomy.name }}</h1>

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -1,0 +1,13 @@
+{% extends "right-aside.html" %}
+
+{% block main_content %}
+
+<h1><a href="/{{ taxonomy.slug }}">{{ taxonomy.name }}</a>: {{ term.name }}</h1>
+<ul>
+    {% for page in term.pages %}
+        <li><a href="{{ page.path }}">{{ page.title }}</a> {{ page.description | markdown | safe }}</li>
+    {% endfor %}
+
+</ul>
+
+{% endblock main_content %}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -1,4 +1,4 @@
-{% extends "right-aside.html" %}
+{% extends "taxonomy.html" %}
 
 {% block main_content %}
 


### PR DESCRIPTION
### Description

This PR replaces the alphabetical only list for documentation topics with some content from `valkey/valkey-doc`

![Screenshot 2024-06-17 at 11 23 57 AM](https://github.com/valkey-io/valkey-io.github.io/assets/1152927/8654eca5-b701-4fa8-8f52-7852bbf1795d)

Removes the handful of topics listed on `/docs/` (Persistence, ACL, Keyspace Notification, all listed in `/docs/topics/`) and replaces it with a submenu for documentation:

![Screenshot 2024-06-17 at 11 24 07 AM](https://github.com/valkey-io/valkey-io.github.io/assets/1152927/5074a5cb-3fa8-4362-8220-a72e2aef1193)


Additionally, this adds a taxonomy for technical blog posts so they can be categorized and listed in a distinct menu item. 


 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
