### PR TITLE
removes topics from review list

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,19 +32,7 @@ review_list = [
     "/topics/internals/",
     "/topics/latency/",
     "/topics/lua-api/",
-    "/topics/modules-blocking-ops/",
-    "/topics/modules-intro/",
-    "/topics/pipelining/",
-    "/topics/programmability/",
-    "/topics/protocol/",
-    "/topics/pubsub/",
     "/topics/rdd/",
-    "/topics/replication/",
-    "/topics/security/",
-    "/topics/sentinel-clients/",
-    "/topics/sentinel/",
-    "/topics/transactions/",
-    "/topics/cluster-spec/",
     "/topics/history/"
 ]
 


### PR DESCRIPTION
### Description

valkey-io/valkey-doc#153 makes several items on the review list no longer needed. This PR removes them from the review list and consequently removes the rendered warning.
 
### Issues Resolved

#94 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
