### PR TITLE
Move to zola 19 for deploy

### DIFF
--- a/.github/workflows/zola-deploy.yml
+++ b/.github/workflows/zola-deploy.yml
@@ -39,7 +39,7 @@ jobs:
           ./build/init-topics.sh ../valkey-doc/topics 
           ./build/init-commands.sh ../valkey-doc/commands ../valkey/src/commands
       - name: Build only
-        uses: shalzz/zola-deploy-action@v0.18.0
+        uses: shalzz/zola-deploy-action@v0.19.0
         env:
           BUILD_DIR: website
           BUILD_ONLY: true


### PR DESCRIPTION
### Description

In https://github.com/valkey-io/valkey-io.github.io/commit/0ab9347c345327f58e5b22cdeb23f97928d38433, we moved to `generate_feeds`, which was only introduced in zola 19. Since this will be the default version folks install, move the deploy to zola 19 as well. See https://github.com/getzola/zola/releases/tag/v0.19.0 for release notes.

I didn't find anything else that seemed to be broken when doing the update.
 
### Issues Resolved

Closes https://github.com/valkey-io/valkey-io.github.io/issues/103.

### Check List
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
