### PR TITLE
Valkey 8 downloads

### DIFF
--- a/content/download/releases/_index.md
+++ b/content/download/releases/_index.md
@@ -1,4 +1,5 @@
 +++
 page_template= "release-page.html"
+template= "release-section.html"
 sort_by= "date"
 +++

--- a/content/download/releases/v8-0-0.md
+++ b/content/download/releases/v8-0-0.md
@@ -1,0 +1,32 @@
+---
+title: "8.0.0"
+date: 2024-09-16
+
+extra:
+    tag: "8.0.0"
+    artifact_source: https://d307a34p6mmcbn.cloudfront.net/releases/
+    artifact_fname: "valkey"
+    container_registry:
+        - 
+            name: "Docker Hub"
+            link: https://hub.docker.com/r/valkey/valkey/
+            id: "valkey/valkey"
+            tags:
+                - "8.0.0"
+                - "8.0.0-bookworm"
+                - "8.0.0-alpine"
+                - "8.0.0-alpine3.20"
+    packages:
+
+    artifacts:
+        -   distro: bionic
+            arch: 
+                -   arm64
+                -   x86_64
+        -   distro: focal
+            arch:
+                -   arm64
+                -   x86_64
+---
+
+Valkey 8.0.0 Release

--- a/content/download/releases/v8-0-0.md
+++ b/content/download/releases/v8-0-0.md
@@ -4,7 +4,7 @@ date: 2024-09-16
 
 extra:
     tag: "8.0.0"
-    artifact_source: https://d307a34p6mmcbn.cloudfront.net/releases/
+    artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
         - 

--- a/templates/download.html
+++ b/templates/download.html
@@ -1,13 +1,21 @@
 {% extends "right-aside.html" %}
 
 {% block subhead_content%}
-<h1 class="page-title">Download</h1>
+<h1 class="page-title">Download Latest</h1>
 {% endblock subhead_content%}
 {% block main_content %}
+
 
 {% set release_section = get_section(path="download/releases/_index.md") %}
 {% set most_recent_release_page = release_section.pages | slice(end= 1)  %}
 {% set release_date = most_recent_release_page[0].date %}
 {% set release = most_recent_release_page[0].extra %}
+
+You can get the latest release of Valkey ({{ release.tag }}) from this page.<br />
+The <a href="./releases/">releases</a> page contains links to download all current and previous releases (including any security fixes for previous released versions).<br />
+<br />
+
+<hr />
+
 {% include "includes/release.html" %}
 {% endblock main_content %}

--- a/templates/includes/release.html
+++ b/templates/includes/release.html
@@ -1,6 +1,14 @@
 <strong>Release Date:</strong>  {{ release_date | date(format="%Y-%m-%d") }} <br/> 
 <strong>GitHub Release:</strong> <a href="https://github.com/valkey-io/valkey/releases/tag/{{release.tag}}">{{release.tag}}</a><br />
 <hr />
+
+{% if most_recent_release_page  %}
+    {% set release_meta = most_recent_release_page %}
+{% else %}
+    {% set release_meta = page %}
+{% endif %}
+
+
 {% for registry in release.container_registry %}
     <h2>{{registry.name}} <small>(<a href="{{registry.link}}">{{registry.id}}</a>)</small></h2>
     <p>Tags:</p>

--- a/templates/includes/release.html
+++ b/templates/includes/release.html
@@ -2,13 +2,6 @@
 <strong>GitHub Release:</strong> <a href="https://github.com/valkey-io/valkey/releases/tag/{{release.tag}}">{{release.tag}}</a><br />
 <hr />
 
-{% if most_recent_release_page  %}
-    {% set release_meta = most_recent_release_page %}
-{% else %}
-    {% set release_meta = page %}
-{% endif %}
-
-
 {% for registry in release.container_registry %}
     <h2>{{registry.name}} <small>(<a href="{{registry.link}}">{{registry.id}}</a>)</small></h2>
     <p>Tags:</p>

--- a/templates/release-section.html
+++ b/templates/release-section.html
@@ -1,0 +1,38 @@
+{% extends "right-aside.html" %}
+
+{% block subhead_content%}
+<h1 class="page-title">Valkey Releases</h1>
+{% endblock subhead_content%}
+{% block main_content %}
+
+
+{% set_global release_lines = [] %}
+
+
+{% for release in section.pages %}
+    {% set split_ver = release.extra.tag | split(pat=".")%}
+    {% set major = split_ver | nth(n= 0) %}
+    {% set minor = split_ver | nth(n= 1) %}
+    {% set patch = split_ver | nth(n= 2) %}
+
+    
+    {% set_global release_lines = release_lines | concat(with=major) %}
+{% endfor %}
+
+{% set release_lines_unique = release_lines | unique %}
+{% for line in release_lines_unique %}
+    <h2>{{ line }}.x.x</h2>
+    <ul>
+    {% for release in section.pages %}
+        {% set split_ver = release.extra.tag | split(pat=".")%}
+        {% set major = split_ver | nth(n= 0) %}
+
+        {% if major == line %}
+            <li><a href="{{ release.permalink }}"> {{ release.extra.tag }}</a> <small>(Released {{ release.date }})</small></li>
+        {% endif %}
+    {% endfor %}
+</ul>
+{% endfor %}
+
+
+{% endblock main_content %}


### PR DESCRIPTION
### Description

This adds 
- a stub for Valkey 8 GA release 
- The ability to access previous releases via `/download/releases/`

NOTE: This is draft until ready for release.

#### Screenshot of `/download/`

![Screenshot 2024-09-11 at 12 57 32 PM](https://github.com/user-attachments/assets/73626035-ef0a-415d-94d6-77245f3ed654)


#### Screenshot of `/download/releases/`

![Screenshot 2024-09-11 at 12 57 40 PM](https://github.com/user-attachments/assets/29d377e8-010e-4e4c-a0c9-c848dd44bed6)

(Each release as a permalink with download info - these already exist today: e.g. https://valkey.io/download/releases/v7-2-5/ )

### Issues Resolved

<!-- List any issues this PR will resolve. -->
<!-- Example: closes #1234 -->

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
