### PR TITLE
Update the CDN links for binaries with the new subdomain `download.valkey.io`

### DIFF
--- a/content/download/releases/v7-2-5.md
+++ b/content/download/releases/v7-2-5.md
@@ -3,7 +3,7 @@ title: "7.2.5"
 date: 2024-04-15
 extra:
     tag: "7.2.5"
-    artifact_source: https://d307a34p6mmcbn.cloudfront.net/releases/
+    artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
         - 

--- a/content/download/releases/v7-2-6.md
+++ b/content/download/releases/v7-2-6.md
@@ -3,7 +3,7 @@ title: "7.2.6"
 date: 2024-07-31
 extra:
     tag: "7.2.6"
-    artifact_source: https://d307a34p6mmcbn.cloudfront.net/releases/
+    artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
         - 


### PR DESCRIPTION
### Description

Update the CDN links with the new subdomain ` download.valkey.io`
Try downloading using this link: https://download.valkey.io/releases/valkey-7.2.6-focal-arm64.tar.gz
```
> nslookup download.valkey.io
Non-authoritative answer:
download.valkey.io	canonical name = d307a34p6mmcbn.cloudfront.net.
```
### Issues Resolved

No github issue was created.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
