### PR TITLE
fix the filename and meta data for correct pub date for 1 million RPS blog (Part 2)

### DIFF
--- a/content/blog/2024-09-13-unlock-one-million-rps-part2.md
+++ b/content/blog/2024-09-13-unlock-one-million-rps-part2.md
@@ -5,7 +5,7 @@ title= "Unlock 1 Million RPS: Experience Triple the Speed with Valkey - part 2"
 # For the most part, you can leave this as the day you _started_ the post.
 # The maintainers will update this value before publishing
 # The time is generally irrelvant in how Valkey published, so '01:01:01' is a good placeholder
-date= 2024-09-11 01:01:01
+date= 2024-09-13 01:01:01
 # 'description' is what is shown as a snippet/summary in various contexts.
 # You can make this the first few lines of the post or (better) a hook for readers.
 # Aim for 2 short sentences.


### PR DESCRIPTION
### Description

The filename date and frontmatter date didn't match (each other) or the actual intended publish date.
 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
