### PR TITLE
Link release notes in the Documention menu

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -12,3 +12,4 @@ page_template = "docs-page.html"
     * [ACL](/topics/acl/)
 * Valkey Manual
   * [Keyspace Notifications](/topics/keyspace/)
+* [Release Notes](topics/release-notes/)


### PR DESCRIPTION
### Description

Add the recently created release notes page in the `Documentation` menu. Reference: https://github.com/valkey-io/valkey-doc/pull/171
 
### Issues Resolved

No GH issue open.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
