### PR TITLE
addes patch releases for 7.2.7 and 8.0.1 to downloads page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -62,4 +62,4 @@ publish_hold = [
     "/topics/rdd/"
 ]
 
-banner = "Valkey 8.0.0 is faster, more efficient, and more reliable. [Read more](https://valkey.io/blog/valkey-8-ga/) or get [Valkey 8.0.0](/download/releases/v8-0-0/) today!"
+banner = "Valkey 8.0 is faster, more efficient, and more reliable. [Read more](/blog/valkey-8-ga/) or get [Valkey 8.0](/download/releases/v8-0-1/) today!"

--- a/content/blog/2024-09-16-valkey-8-ga.md
+++ b/content/blog/2024-09-16-valkey-8-ga.md
@@ -24,3 +24,5 @@ Valkey 8.0.0 has gone through multiple rounds of release candidates, testing, an
 The Technical Steering Committee considers it ready for production usage.
 You can [build from source](https://github.com/valkey-io/valkey/tree/8.0.0), start [installing the binaries, or deploy the containers](/download/) today.
 Expect package managers to pick up the latest version in the coming days.
+
+**Note:** [Valkey 8.0.1](https://github.com/valkey-io/valkey/tree/8.0.1) was released on October 2, read the release notes on [GitHub](https://github.com/valkey-io/valkey/blob/8.0.1/00-RELEASENOTES).

--- a/content/download/releases/v7-2-7.md
+++ b/content/download/releases/v7-2-7.md
@@ -1,0 +1,38 @@
+---
+title: "7.2.7"
+date: 2024-10-02 01:01:01
+
+extra:
+    tag: "7.2.7"
+    artifact_source: https://download.valkey.io/releases/
+    artifact_fname: "valkey"
+    container_registry:
+        - 
+            name: "Docker Hub"
+            link: https://hub.docker.com/r/valkey/valkey/
+            id: "valkey/valkey"
+            tags:
+                - "7.2.7"
+                - "7.2.7-bookworm"
+                - "7.2.7-alpine"
+                - "7.2.7-alpine3.20"
+    packages:
+        -
+            url: https://packages.fedoraproject.org/pkgs/valkey/valkey/
+            name: Fedora
+            id: 'valkey'
+        -
+            name: EPEL
+            id: 'valkey'
+    artifacts:
+        -   distro: bionic
+            arch: 
+                -   arm64
+                -   x86_64
+        -   distro: focal
+            arch:
+                -   arm64
+                -   x86_64
+---
+
+Valkey 7.2.7 Release

--- a/content/download/releases/v8-0-1.md
+++ b/content/download/releases/v8-0-1.md
@@ -1,0 +1,32 @@
+---
+title: "8.0.1"
+date: 2024-10-02 01:01:02
+
+extra:
+    tag: "8.0.1"
+    artifact_source: https://download.valkey.io/releases/
+    artifact_fname: "valkey"
+    container_registry:
+        - 
+            name: "Docker Hub"
+            link: https://hub.docker.com/r/valkey/valkey/
+            id: "valkey/valkey"
+            tags:
+                - "8.0.1"
+                - "8.0.1-bookworm"
+                - "8.0.1-alpine"
+                - "8.0.1-alpine3.20"
+    packages:
+
+    artifacts:
+        -   distro: bionic
+            arch: 
+                -   arm64
+                -   x86_64
+        -   distro: focal
+            arch:
+                -   arm64
+                -   x86_64
+---
+
+Valkey 8.0.1 Release

--- a/templates/release-section.html
+++ b/templates/release-section.html
@@ -28,7 +28,7 @@
         {% set major = split_ver | nth(n= 0) %}
 
         {% if major == line %}
-            <li><a href="{{ release.permalink }}"> {{ release.extra.tag }}</a> <small>(Released {{ release.date }})</small></li>
+            <li><a href="{{ release.permalink }}"> {{ release.extra.tag }}</a> <small>(Released {{ release.date | date(format="%Y-%m-%d") }})</small></li>
         {% endif %}
     {% endfor %}
 </ul>


### PR DESCRIPTION
### Description

Based on valkey-io/valkey#1115

- adds download metadata about 7.2.7 and 8.0.1
- Updates banner to be more general
- Adds note about 8.0.1 to recent 8.0.0 blog post
- adds logic to always sort releases by date

This will remain in draft until #1115 is merged  

### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
