### PR TITLE
Improve header menu blog + connect

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -22,11 +22,12 @@
         <a role="menuitem" href="/download/">Download</a>
         <a role="menuitem" href="/docs/">Documentation</a>
         <a role="menuitem" href="/commands/">Commands</a>
+        <a role="menuitem" href="/blog/">Blog</a>
         <div class="has-submenu">
           <span>Community</span>
             <div class="submenu">
-              <a role="menuitem" href="/blog/">Blog</a>
               <a role="menuitem" href="https://github.com/orgs/valkey-io/discussions">Forum</a>
+              <a role="menuitem" href="/connect/">Connect</a>
             </div>
         </div>
       </nav>

--- a/templates/default.html
+++ b/templates/default.html
@@ -26,7 +26,7 @@
         <div class="has-submenu">
           <span>Community</span>
             <div class="submenu">
-              <a role="menuitem" href="https://github.com/orgs/valkey-io/discussions">Forum</a>
+              <a role="menuitem" target="_blank" href="https://github.com/orgs/valkey-io/discussions">Forum</a>
               <a role="menuitem" href="/connect/">Connect</a>
             </div>
         </div>


### PR DESCRIPTION
### Description

- Move blog to a dedicated menu item at top level, so people can much easier find it (also it's not really "community", its just a blog)
- Under Community I now also added 'Connect'
- Open Github.com link in new tab
 
### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
