### PR TITLE
organizes documentation topics, normalizes docs headings

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,14 +1,11 @@
 +++
-title = "Docs"
-template = "fullwidth.html"
+title = "Documentation"
+template = "block-menu.html"
 page_template = "docs-page.html"
+[extra]
+body_class=  "blocks-page"
 +++
 
-* [Command Reference](/commands/)
-* [All Documentation Topics](/topics/)
-* Management
-  * [Persistence](/topics/persistence/)
-  * Security
-    * [ACL](/topics/acl/)
-* Valkey Manual
-  * [Keyspace Notifications](/topics/keyspace/)
+
+* [Command Reference](/commands/) A categorized listing of all Valkey commands
+* [Documentation by topic](/topics/) In-depth documentation covering a wide variety of operational and usage subjects

--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -546,6 +546,54 @@ pre table {
   
 }
 
+.index-entry {
+  padding: 0.5em 1em;
+  margin-bottom: 0.5em;
+}
+
+.block-menu ul li,
+.index-entry {
+  border: 1px solid $line;
+  border-radius: 3px;
+  a {
+    display: block;
+  }
+}
+
+.block-menu {
+  ul {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    list-style-type: none;
+    padding: 0;
+    gap: 1em;
+    li {
+      text-align: center;
+      padding: 1em;
+      flex: 1 1 0px;
+      a {
+        text-align: center;
+        padding-bottom: 1em;
+      }
+    }
+  }
+}
+
+.blocks-page {
+  .container {
+    padding-right: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .block-menu ul {
+    display: block;
+    li {
+      margin-bottom: 1em;
+    }
+  }
+}
 
 
 

--- a/templates/block-menu.html
+++ b/templates/block-menu.html
@@ -1,0 +1,8 @@
+{% extends "fullwidth.html" %}
+
+
+{% block main_content %}
+<div class="block-menu">
+{{ page.content | markdown | safe }}
+</div>
+{% endblock main_content %}

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -70,3 +70,8 @@
 {% endfor %}
 </ul>
 {% endblock related_content %}
+
+
+{% block subhead_content %}
+<h1 class="page-title">Documentation: Command Reference</h1>
+{% endblock subhead_content %}

--- a/templates/default.html
+++ b/templates/default.html
@@ -2,8 +2,9 @@
 <html lang="{{ page.lang | default(value=config.default_language) }}">
 {% include "includes/head.html" %}
 <body 
-  {%- if page.extra.sectionid -%}id="{{ page.extra.sectionid }}"{%- endif -%}
-  {%- if page.extra.body_class -%}class="{{ page.body_class }}"{%- endif -%}
+  {%- if page.extra.sectionid -%} id="{{ page.extra.sectionid }}"{%- endif -%}
+  {% if page.extra.body_class %} class="{{ page.extra.body_class }}"{% endif %}
+  {% if section.extra.body_class %} class="{{ section.extra.body_class }}"{% endif %}
   >
   {%- if config.extra.banner -%}
   <div class="banner">
@@ -20,8 +21,13 @@
       </a>
       <nav role="navigation" aria-label="Main">
         <a role="menuitem" href="/download/">Download</a>
-        <a role="menuitem" href="/docs/">Documentation</a>
-        <a role="menuitem" href="/commands/">Commands</a>
+        <div class="has-submenu">
+          <a role="menuitem" href="/docs/">Documentation</a>
+            <div class="submenu">
+              <a role="menuitem" href="/commands/">Command Reference</a>
+              <a role="menuitem" href="/topics/">Documentation by Topic</a>
+            </div>
+        </div>
         <a role="menuitem" href="/blog/">Blog</a>
         <div class="has-submenu">
           <span>Community</span>

--- a/templates/docs-page.html
+++ b/templates/docs-page.html
@@ -21,7 +21,7 @@
 
 {% block subhead_content %}
 {% if has_frontmatter and frontmatter_title %}
-<h1 class="page-title">{{ frontmatter_title }}</h1>
+<h1 class="page-title">Documentation: {{ frontmatter_title }}</h1>
 {% endif  %}
 {% endblock subhead_content %}
 

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -1,12 +1,29 @@
-{% extends "fullwidth.html" %}
+{% extends "right-aside.html" %}
 
 {% import "macros/docs.html" as docs %}
 
+{% block subhead_content %}
+<h1 class="page-title">Documentation by topic</h1>
+{% endblock subhead_content %}
+
 {% block main_content %}
+
 {% set list = [] %}
 {% if section.pages | length == 0 %}
 <strong>No docs pages found.</strong> You likely need to build the documentation pages. See "Building additional content" in README.md file.
 {% endif %}
+
+{% set docs_file_contents = docs::load(slug= "index") %}
+{% set frontmatter = docs::extract_frontmatter(content= docs_file_contents) %}
+{% set page_contents = docs::extract_markdown(content= docs_file_contents) %}
+{%- set content_with_fixed_links = docs::fix_links(content= page_contents) -%}
+
+
+{{ content_with_fixed_links  | markdown | safe }}
+{% endblock main_content %}
+
+{% block related_content %}
+<h2>Alphabetical Index</h2>
 {% for page in section.pages %}
     {% set docs_file_contents = docs::load(slug= page.slug) %}
     {% set frontmatter = docs::extract_frontmatter(content= docs_file_contents) %}
@@ -26,7 +43,9 @@
     {% set topic_list = load_data(literal= "[" ~ joined_list ~ "]", format="json") | sort(attribute="title") %} 
     
     {% for topic in topic_list %}
-        <a href="{{ topic.path }}">{{ topic.title }}</a> {{ topic.description | safe }} <br />
+        <div class="index-entry">
+            <a href="{{ topic.path }}">{{ topic.title }}</a> {{ topic.description | safe }} <br />
+        </div>
     {% endfor %}
 
-{% endblock main_content %}
+{% endblock related_content %}


### PR DESCRIPTION
### Description

This supersedes PR #87

This PR puts documentation in to categories, alters the top nav to make a single documentation drop down, and normalizes the heading in the documentation pages.

![Screenshot 2024-10-16 at 2 43 58 PM](https://github.com/user-attachments/assets/f8e5f985-f5e9-40ac-b10f-945b97f4d9c8)
![Screenshot 2024-10-16 at 2 43 53 PM](https://github.com/user-attachments/assets/cf59c10d-5dbf-4953-94f1-d1ff217953bf)
![Screenshot 2024-10-16 at 2 43 43 PM](https://github.com/user-attachments/assets/73ac5345-8835-4884-acd3-7c3d9b392bb7)

 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
