### PR TITLE
Link rewriter update

### DIFF
--- a/templates/macros/command.html
+++ b/templates/macros/command.html
@@ -57,5 +57,6 @@
     | regex_replace(pattern=`\]\(\.\./topics/(?P<fname>.*?).md#(?P<hash>.*?)\)`, rep=`](/topics/$fname#$hash)`)
     | regex_replace(pattern=`\]\(\.\./topics/(?P<fname>.*?).md\)`, rep=`](/topics/$fname)`)
     | regex_replace(pattern=`\[(?P<token>.*?)\]:\s+\.\./topics/(?P<fname>.*?).md`, rep=`[$token]: /topics/$fname`)
+    | regex_replace(pattern=`\[(?P<token>.*?)\]:\s+(?P<fname>.*?).md`, rep=`[$token]: $fname`)
     }}
 {%- endmacro fix_links -%}

--- a/templates/macros/docs.html
+++ b/templates/macros/docs.html
@@ -29,11 +29,32 @@
         | regex_replace(pattern=`\]\(\.\./commands/(?P<fname>\w.*?)(.md)?#(?P<hash>.*?)\)`, rep=`](/commands/$fname#$hash)`) 
         | regex_replace(pattern=`\]\(\.\./commands/(?P<fname>\w.*?)(.md)?\)`, rep=`](/commands/$fname)`)
         | regex_replace(pattern=`\]\(\.\./commands/#(?P<hash>\w.*?)\)`, rep=`](/commands/#$hash)`) 
+        | regex_replace(pattern=`\]\((?P<fname>\w.*?)(.md)\)`, rep=`](/topics/$fname)`)
         | regex_replace(pattern=`\]\((?P<fname>\w.*?)(.md)?#(?P<hash>.*?)\)`, rep=`](/topics/$fname#$hash)`)
         | regex_replace(pattern=`\]\((?P<fname>.*?).png\)`, rep=`](/topics/$fname.png)`)
         | regex_replace(pattern=`\]\((?P<fname>.*?).gif\)`, rep=`](/topics/$fname.gif)`)
         | regex_replace(pattern=`\]\((?P<fname>\w.*?)(.md)?\)`, rep=`](/topics/$fname)`)
         | regex_replace(pattern=`\]\(\-(?P<url>https?:\/\/.*?\))`, rep=`]($url`)
         | regex_replace(pattern=`\]\(\--(?P<hash>.*?\))`, rep=`](#$hash`)
+        | regex_replace(pattern=`\.\.\/commands\/`, rep=`/commands/`)
+
+        | regex_replace(pattern=`\[(?<id>.*)\]:\s*https://(?P<url>.*)`, rep=`[$id} https://$url`)
+
+        | regex_replace(pattern=`\[(?<id>.*)\]:\s*(?P<topic>.*)(\.md)`, rep=`[$id]: /topics/$topic`)
+
+        | regex_replace(pattern=`\]\(\/topics\/(?P<url>http:\/\/.*?\))`, rep=`]($url`)
+
+
+
+        | regex_replace(pattern=`\[(?<id>.*)\}\s*(?P<url>.*)`, rep=`[$id]: $url`)
 }}
+
+{# 
+    | regex_replace(pattern=`\[(?<id>.*)\]:\s*(?P<topic>.*)(\.md)`, rep=`[$id]: /topics/$topic`)
+
+    
+
+    | regex_replace(pattern=`\[(?<id>.*)\]:\s*(https\:\/\/)(?P<url>.*)`, rep=`[$id]: /$url`)
+    
+#}
 {%- endmacro fix_links -%}

--- a/templates/macros/docs.html
+++ b/templates/macros/docs.html
@@ -48,13 +48,4 @@
 
         | regex_replace(pattern=`\[(?<id>.*)\}\s*(?P<url>.*)`, rep=`[$id]: $url`)
 }}
-
-{# 
-    | regex_replace(pattern=`\[(?<id>.*)\]:\s*(?P<topic>.*)(\.md)`, rep=`[$id]: /topics/$topic`)
-
-    
-
-    | regex_replace(pattern=`\[(?<id>.*)\]:\s*(https\:\/\/)(?P<url>.*)`, rep=`[$id]: /$url`)
-    
-#}
 {%- endmacro fix_links -%}


### PR DESCRIPTION
### Description

In looking into #139, I ran the site through a site-wide link checker and came across a few corner cases the link rewriter didn't catch.

Before this change [filiph/linkcheck](https://github.com/filiph/linkcheck), resulted in the following final output:

```
Stats:
    8786 links
     216 destination URLs
     604 URLs ignored
      72 warnings
      17 errors
```

After this change, the same script outputs:

```
Stats:
    8818 links
     203 destination URLs
     611 URLs ignored
      72 warnings
       3 errors
```

The 3 remaining errors are related to known issues: missing`/clients/` and `/modules/` (the warnings are largely from `/topics/protocol` missing anchors, which is also known).


### Issues Resolved

#139 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
