### PR TITLE
Remove valkey 8 notice banner (up for 1+ month)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -49,5 +49,3 @@ publish_hold = [
     "/topics/protocol/",
     "/topics/rdd/"
 ]
-
-banner = "Valkey 8.0 is faster, more efficient, and more reliable. [Read more](/blog/valkey-8-ga/) or get [Valkey 8.0](/download/releases/v8-0-1/) today!"


### PR DESCRIPTION
### Description

The banner for Valkey 8 has been up for more than a month. This PR removes the notice banner. 

### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
