### PR TITLE
adds revises downloads page, adds package page, updates package data

### DIFF
--- a/_data/releases.toml
+++ b/_data/releases.toml
@@ -1,0 +1,7 @@
+artifact_source = "https://download.valkey.io/releases/"
+
+[distros]
+
+[distros.notes]
+epel = "Valkey EPEL packages are used in AlmaLinux, Oracle Linux, RHEL (=< 10)"
+

--- a/content/download/packages.md
+++ b/content/download/packages.md
@@ -1,0 +1,11 @@
++++
+template = "packages.html"
+title = "Packages"
++++
+
+You can get Valkey from a variety of package managers in many different operating systems.
+In the chart below, the filled dot (⬤) indicates that the Valkey package for the version in the left most column is available for the package manager indicated in the corresponding column header, the unfilled dot (◯) indicates that the package is not yet available.
+Some package managers may be used across many different distributions (i.e. EPEL with AlmaLinux, RHEL, Oracle Linux, etc. ) or operating systems (i.e. Homebrew or Nix with MacOS and Linux).
+
+This information is maintained on a best-effort basis, if you believe that it is inaccurate, [create an issue](https://github.com/valkey-io/valkey-io.github.io/issues/new/choose).
+Requests for new packages or updates should go to the relevant process for each package manager.

--- a/content/download/releases/v7-2-5.md
+++ b/content/download/releases/v7-2-5.md
@@ -3,7 +3,6 @@ title: "7.2.5"
 date: 2024-04-15
 extra:
     tag: "7.2.5"
-    artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
         - 
@@ -23,6 +22,30 @@ extra:
         -
             name: EPEL
             id: 'valkey'
+        - 
+            name: Ubuntu
+            id: valkey
+            url: https://launchpad.net/ubuntu/+source/valkey
+        -
+            name: Arch Linux
+            id: valkey
+            url: https://archlinux.org/packages/extra/x86_64/valkey/
+        -
+            name: Homebrew
+            id: valkey
+            url: https://formulae.brew.sh/formula/valkey
+        -
+            name: FreeBSD
+            id: databases/valkey
+            url: https://www.freshports.org/databases/valkey/
+        -
+            name: OpenSUSE
+            id: valkey
+            url: https://build-test-1.opensuse.org/package/show/openSUSE:Factory/valkey
+        -
+            name: Wolfi
+            id: valkey
+            url: https://github.com/wolfi-dev/os/blob/main/valkey.yaml
     artifacts:
         -   distro: bionic
             arch: 

--- a/content/download/releases/v7-2-6.md
+++ b/content/download/releases/v7-2-6.md
@@ -3,7 +3,6 @@ title: "7.2.6"
 date: 2024-07-31
 extra:
     tag: "7.2.6"
-    artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
         - 
@@ -23,6 +22,30 @@ extra:
         -
             name: EPEL
             id: 'valkey'
+        -
+            name: Arch Linux
+            id: valkey
+            url: https://archlinux.org/packages/extra/x86_64/valkey/
+        -
+            name: Homebrew
+            id: valkey
+            url: https://formulae.brew.sh/formula/valkey
+        -
+            name: FreeBSD
+            id: databases/valkey
+            url: https://www.freshports.org/databases/valkey/
+        -
+            name: OpenSUSE
+            id: valkey
+            url: https://build-test-1.opensuse.org/package/show/openSUSE:Factory/valkey
+        -
+            name: Nix
+            id: valkey
+            url: https://mynixos.com/nixpkgs/package/valkey
+        -
+            name: Wolfi
+            id: valkey
+            url: https://github.com/wolfi-dev/os/blob/main/valkey.yaml
     artifacts:
         -   distro: bionic
             arch: 

--- a/content/download/releases/v7-2-7.md
+++ b/content/download/releases/v7-2-7.md
@@ -4,7 +4,6 @@ date: 2024-10-02 01:01:01
 
 extra:
     tag: "7.2.7"
-    artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
         - 
@@ -18,12 +17,9 @@ extra:
                 - "7.2.7-alpine3.20"
     packages:
         -
-            url: https://packages.fedoraproject.org/pkgs/valkey/valkey/
-            name: Fedora
-            id: 'valkey'
-        -
-            name: EPEL
-            id: 'valkey'
+            name: Alpine
+            id: valkey
+            url: https://pkgs.alpinelinux.org/packages?name=valkey&branch=edge&repo=&arch=x86_64&origin=&flagged=&maintainer=
     artifacts:
         -   distro: bionic
             arch: 

--- a/content/download/releases/v8-0-0.md
+++ b/content/download/releases/v8-0-0.md
@@ -4,7 +4,6 @@ date: 2024-09-16
 
 extra:
     tag: "8.0.0"
-    artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
         - 
@@ -17,7 +16,33 @@ extra:
                 - "8.0.0-alpine"
                 - "8.0.0-alpine3.20"
     packages:
-
+        -
+            name: Azure Linux
+            id: valkey
+            url: https://github.com/microsoft/azurelinux/tree/3.0/SPECS/valkey/valkey.spec
+        -
+            name: FreeBSD
+            id: databases/valkey
+            url: https://www.freshports.org/databases/valkey/
+        -
+            name: Homebrew
+            id: valkey
+            url: https://formulae.brew.sh/formula/valkey
+        -
+            name: Wolfi
+            id: valkey
+            url: https://github.com/wolfi-dev/os/blob/main/valkey.yaml
+        -
+            url: https://packages.fedoraproject.org/pkgs/valkey/valkey/
+            name: Fedora
+            id: 'valkey'
+        -
+            name: Arch Linux
+            id: valkey
+            url: https://archlinux.org/packages/extra/x86_64/valkey/
+        -
+            name: EPEL
+            id: 'valkey'
     artifacts:
         -   distro: bionic
             arch: 

--- a/content/download/releases/v8-0-1.md
+++ b/content/download/releases/v8-0-1.md
@@ -4,7 +4,6 @@ date: 2024-10-02 01:01:02
 
 extra:
     tag: "8.0.1"
-    artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
         - 
@@ -17,7 +16,34 @@ extra:
                 - "8.0.1-alpine"
                 - "8.0.1-alpine3.20"
     packages:
-
+        -
+            url: https://packages.fedoraproject.org/pkgs/valkey/valkey/
+            name: Fedora
+            id: 'valkey'
+        -
+            name: EPEL
+            id: 'valkey'
+        -
+            name: Arch Linux
+            id: valkey
+            url: https://archlinux.org/packages/extra/x86_64/valkey/
+        -
+            name: FreeBSD
+            id: databases/valkey
+            url: https://www.freshports.org/databases/valkey/
+        -
+            name: OpenSUSE
+            id: valkey
+            url: https://build-test-1.opensuse.org/package/show/openSUSE:Factory/valkey
+        -
+            name: Homebrew
+            id: valkey
+            url: https://formulae.brew.sh/formula/valkey
+        -
+            name: Wolfi
+            id: valkey
+            url: https://github.com/wolfi-dev/os/blob/main/valkey.yaml
+ 
     artifacts:
         -   distro: bionic
             arch: 

--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -614,6 +614,62 @@ pre table {
   margin-right: 20px;
 }
 
+.packages-table,
+.package-manager-table {
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
+
+  tbody tr:nth-child(odd) {
+    background-color: $grey-lt-000;
+  }
+
+  tbody {
+    tr {
+      th {
+        font-weight: 400;
+      }
+    }
+  }
+  thead {
+    tr {
+      th {
+        border-bottom: 1px solid $grey-dk-200;
+      }
+    }
+  }
+}
+
+
+.package-manager-table {
+  th:nth-child(1) {
+    width: 25%
+  }
+  th:nth-child(2) {
+    width: 25%
+  }
+
+  th, td {
+    text-align: left;
+  }
+}
+
+.packages-table {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  thead th {
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+  }
+  th, td {
+    text-align: center;
+  }
+  .has-package, .no-package {
+    font-size: 0.8em;
+  }
+}
+
 .author-info {
   flex: 1;
   text-align: left;

--- a/templates/includes/release.html
+++ b/templates/includes/release.html
@@ -1,9 +1,10 @@
 <strong>Release Date:</strong>  {{ release_date | date(format="%Y-%m-%d") }} <br/> 
 <strong>GitHub Release:</strong> <a href="https://github.com/valkey-io/valkey/releases/tag/{{release.tag}}">{{release.tag}}</a><br />
 <hr />
+{% set releases_data = load_data(path="/_data/releases.toml") %}
 
 {% for registry in release.container_registry %}
-    <h2>{{registry.name}} <small>(<a href="{{registry.link}}">{{registry.id}}</a>)</small></h2>
+    <h2 id="{{ registry.name| slugify}}">{{registry.name}} <small>(<a href="{{registry.link}}">{{registry.id}}</a>)</small></h2>
     <p>Tags:</p>
     <ul>
         {% for tag in registry.tags %}
@@ -17,24 +18,44 @@
     <hr />
 {% endfor %}
 {% if release.packages %}
-<h2>Package Managers</h2>
-    {% for package_manager in release.packages %}
-        <h3>{{package_manager.name}}:</h3>
-        Package Name: 
-        {% if package_manager.url %}
-            <a href="{{package_manager.url}}">{{ package_manager.id }}</a>
-        {% else %}
-            {{ package_manager.id }}
-        {% endif %}
-    {% endfor %}
+<h2 id="package-managers">Package Managers</h2>
+<table class="package-manager-table">
+    <thead>
+        <tr>
+            <th scope="col">OS/Distro</th>
+            <th scope="col">Package Name</th>
+            <th scope="col">Notes</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for package_manager in  release.packages | sort(attribute="name") %}
+            {% set package_manager_id = package_manager.name | slugify %}
+        <tr>
+            <th id="{{ package_manager_id }}" scope="row">{{package_manager.name}}</th>
+            <td>
+                {% if package_manager.url %}
+                    <a href="{{package_manager.url}}" target="_blank">{{ package_manager.id }}</a>
+                {% else %}
+                    {{ package_manager.id }}
+                {% endif %}
+            </td>
+            <td>
+                {% if releases_data.distros.notes[package_manager_id] %}
+                    {{ releases_data.distros.notes[package_manager_id] }}
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+<p><small><em>Note:</em> <a href="/download/packages">Other versions of Valkey</a> may be available in different package managers.</small></p>
 {% endif %}
 <hr />
-<h2>Binary Artifacts</h2>
+<h2 id="binary">Binary Artifacts</h2>
 {% if release.artifacts %}
 {% for artifact in release.artifacts %}
     {% for arch in  artifact.arch %}
-        {% set fname = release.artifact_source ~ release.artifact_fname ~ "-" ~ release.tag ~ "-" ~ artifact.distro ~ "-" ~ arch ~ ".tar.gz" %}
-        {# {% capture fname %}{{include.content.artifact_source}}{{include.content.artifact_fname}}-{{include.content.tag}}-{{artifact.distro}}-{{arch}}.tar.gz{% endcapture %} #}
+        {% set fname = releases_data.artifact_source ~ release.artifact_fname ~ "-" ~ release.tag ~ "-" ~ artifact.distro ~ "-" ~ arch ~ ".tar.gz" %}
         <a href="{{fname}}">{{arch}} / {{artifact.distro}}</a> <small>(<a href="{{fname}}.sha256">sha256</a>)</small><br />
     {% endfor %}
 {% endfor  %}

--- a/templates/packages.html
+++ b/templates/packages.html
@@ -1,0 +1,58 @@
+{% extends "fullwidth.html" %}
+
+{% block subhead_content%}
+<h1 class="page-title">Packages </h1>
+{% endblock subhead_content%}
+{% block main_content %}
+
+{{ page.content | safe }}
+
+{% set releases_section = get_section(path="download/releases/_index.md") %}
+{% set releases = releases_section.pages | sort(attribute="date") | reverse %}
+
+
+{% set package_names = [] %}
+{% for release in releases %}
+    {% if release.extra.packages %}
+        {% for package in release.extra.packages %}
+            {% set_global package_names = package_names | concat(with= [ package.name ]) %}
+        {% endfor %}
+    {% endif %}
+{% endfor %}
+{% set package_cols = package_names | unique() | sort() %}
+{% set has_package = "⬤" %}
+{% set no_package = "◯" %}
+
+<h2>Valkey packages for each version</h2>
+<table class="packages-table">
+    <thead>
+        <tr>
+            <th scope="col">Version</th>
+        {% for col in package_cols %}
+            <th scope="col" ><div>{{ col }}</div></th>
+        {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for release in releases %}
+            <tr>
+                <th id="{{ release.title | slugify }}" scope="row"><a href="{{release.permalink}}">{{ release.title }}</a></th>
+                {% for col in package_cols %}
+                    {% if release.extra.packages %}
+                        {% set package = release.extra.packages | filter(attribute="name", value= col) %}
+                        {% if package.0 %}       	
+                            <td class="has-package">{{ has_package | safe }}</td>
+                        {% else %}
+                            <td class="no-package">{{ no_package | safe }}</td>
+                        {% endif%}
+                    {% else %}
+                        <td class="no-package">{{ no_package | safe  }}</td>
+                    {% endif %}
+
+                {% endfor %}
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+<small>Note this table may scroll horizontally.</small>
+{% endblock main_content %}


### PR DESCRIPTION
### Description

This revises. the downloads page extensively.

1) Updates to the package manager information at each version
2) Adds a page with grid of versions and package managers.
3) Moves the `artifact_source` from each release files to a central data file since it never changes

Screenshots:


Package Manager page:
![Screenshot 2024-10-23 at 7 52 58 AM](https://github.com/user-attachments/assets/deb3ab7a-8dbb-48c7-a08e-8a5545b5508a)

New section on downloads and each release:
![Screenshot 2024-10-23 at 7 52 44 AM](https://github.com/user-attachments/assets/3946190d-f7a0-4562-bbe5-09494fa32ec7)

### Issues Resolved

#131 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
