### PR TITLE
Add quicklink to the github page to make edits

### DIFF
--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -94,3 +94,10 @@
 {% endif %}
 
 {% endblock main_content %}
+
+{% block related_content %}
+<div class="edit_box">
+    See an error?
+    <a href="https://github.com/valkey-io/valkey-doc/edit/main/commands/{{ page.slug }}.md">Update this Page on Github!</a>
+</div>
+{% endblock related_content %}

--- a/templates/docs-page.html
+++ b/templates/docs-page.html
@@ -39,3 +39,10 @@
     {{ content_with_fixed_links | markdown | safe }}
 {% endif %}
 {% endblock main_content %}
+
+{% block related_content %}
+<div class="edit_box">
+    See an error?
+    <a href="https://github.com/valkey-io/valkey-doc/edit/main/topics/{{ page.slug }}.md">Update this Page on Github!</a>
+</div>
+{% endblock related_content %}


### PR DESCRIPTION
### Description

In an effort to encourage more folks to update the docs, created a button to easily navigate to the valkey-doc repo to update a page. If you click on it, it will take you to your fork (if you have one), allow you to edit and commit it in place, and the submit the PR. This seems like a very easy flow to get people to contribute.
 
### Issues Resolved

My personal sadness.

### Check List
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.


<img width="398" alt="image" src="https://github.com/user-attachments/assets/7434d046-5893-47fb-9c83-2e5481c7503f">

I also originally attached an svg of the github icon, but it felt a bit silly.
