### PR TITLE
allows for `/command/GET/` alongside `/command/get/`

### DIFF
--- a/build/init-commands.sh
+++ b/build/init-commands.sh
@@ -31,12 +31,14 @@ for fname in $(find $1 -maxdepth 1  -iname "*.md")
 do
     base=${fname##*/}
     command=${base%.*}
+    command_upper=$(awk '{ print toupper($0) }' <<< $command)
     if [[ "$command" != "index" ]]; then 
         cat << EOF > "./content/commands/$command.md"
 +++
 # This is a generated stub file.
 # To edit the command description see /commands/$command.md in the 'valkey-doc' repo
 # The command metadata is generated from /src/$command.json in the 'valkey' repo
+aliases = ["/commands/$command_upper/"]
 +++
 EOF
 fi


### PR DESCRIPTION
### Description

I got feedback that some people were getting 404 when they used valkey.io because they copy/pasted upper case commands into the URL.

This adds an uppercase alias to the website so `/command/GET/` forwards to `/command/get/`
 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
