### PR TITLE
Extra valkey in title

### DIFF
--- a/templates/docs-page.html
+++ b/templates/docs-page.html
@@ -12,7 +12,7 @@
     {% set has_frontmatter = true %}
     {% set page_contents = docs::extract_markdown(content= docs_file_contents) %}
     {% if frontmatter_data.title %}
-        {% set frontmatter_title = frontmatter_data.title %}
+        {% set frontmatter_title = docs::remove_valkey_title(title= frontmatter_data.title) %}
     {% endif %} 
 {% else %}
     {% set page_contents = docs_file_contents %}

--- a/templates/docs-page.html
+++ b/templates/docs-page.html
@@ -21,7 +21,7 @@
 
 {% block subhead_content %}
 {% if has_frontmatter and frontmatter_title %}
-<h1 class="page-title">Documentation: {{ frontmatter_title }}</h1>
+<h1 class="page-title">Documentation: {{ docs::remove_valkey_title(title= frontmatter_title)  }}</h1>
 {% endif  %}
 {% endblock subhead_content %}
 

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -33,8 +33,9 @@
         {% set frontmatter_data = load_data(literal= frontmatter, format="yaml") %}
         {% set description = frontmatter_data.description | escape | safe %}
         {% set description_no_line_breaks = description | regex_replace(pattern=`[\u0000-\u001F]`, rep=` `) %}
+        {% set title= docs::remove_valkey_title(title= frontmatter_data.title) %}
 
-        {% set_global list = list | concat(with= ['{ "title" : "' ~ frontmatter_data.title ~ '", "path" : "' ~ page.path ~ '", "description" : "' ~ description_no_line_breaks ~ '" }']) %}
+        {% set_global list = list | concat(with= ['{ "title" : "' ~ title ~ '", "path" : "' ~ page.path ~ '", "description" : "' ~ description_no_line_breaks ~ '" }']) %}
     {% endif %}
    
 

--- a/templates/macros/docs.html
+++ b/templates/macros/docs.html
@@ -7,6 +7,21 @@
 {%- if markdown_content -%}{{ markdown_content }}{% endif %}
 {% endmacro load_doc %}
 
+{%- macro remove_valkey_title(title) -%}
+{%- if title is starting_with("Valkey") -%}
+{%- set noValkey = title | replace(from="Valkey ", to="") -%}
+{%- for letter in noValkey -%}
+  {%- if loop.index == 1 -%}
+    {{ letter | upper }}
+  {%- else -%}
+    {{ letter }}
+  {%- endif -%}
+{%- endfor -%}
+{%- else -%}
+{{ title }}
+{%- endif -%}
+{%- endmacro remove_valkey_title -%}
+
 {%- macro extract_frontmatter(content) %}
 {%- set markdown_split = content | split(pat="---") -%}
 {%- set markdown_part_count = markdown_split | length() -%}


### PR DESCRIPTION
### Description

In valkey-io/valkey-doc#164  @zuiderkwast pointed out that 'Valkey ' was repeated needlessly in the doc titles, leading to silly titles like "Valkey Documentation · Valkey Functions".

This issue resolves the concern by removing "Valkey " from the titles headings on the alphabetical list. 

It smartly recapitalizes the first letter of the title so, for example, a title of "Valkey functions" renders as "Functions" in the alpha list, "Documentation: Functions" in the subhead, and "Valkey Documentation · Functions" in the HTML head `title` tag.


### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
