### PR TITLE
Fix IRQ ranges

### DIFF
--- a/content/blog/2024-09-13-unlock-one-million-rps-part2.md
+++ b/content/blog/2024-09-13-unlock-one-million-rps-part2.md
@@ -112,8 +112,8 @@ grep eth0 /proc/interrupts | awk '{print $1}' | cut -d : -f 1
 ```
 In our setup, lines `48` to `55` are allocated for `eth0` interrupts. Allocate one core per 4 IRQ lines: 
 ```bash 
-for i in {48..50}; do echo 1000 > /proc/irq/$i/smp_affinity; done
-for i in {51..55}; do echo 2000 > /proc/irq/$i/smp_affinity; done  
+for i in {48..51}; do echo 1000 > /proc/irq/$i/smp_affinity; done
+for i in {52..55}; do echo 2000 > /proc/irq/$i/smp_affinity; done
 ```
 Server configuration - launch the Valkey server with these minimal configurations:
 ```bash


### PR DESCRIPTION
I'm assuming pinning 3 IRQs to CPU 12 and 5 IRQs to CPU 13 is not what was intended here.

### Description

This patch fixes what I assume was a typo in this blog post.

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
