### PR TITLE
remove publish hold on protocol docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,11 +41,9 @@ review_list = [
 ]
 
 publish_hold = [
-    "/topics/protocol/",
     "/topics/license/",
     "/topics/internals-eventlib/",
     "/topics/internals-vm/",
     "/topics/internals/",
-    "/topics/protocol/",
     "/topics/rdd/"
 ]


### PR DESCRIPTION
### Description

Removes publishing hold on the protocol documentation after fixes in valkey-io/valkey-doc#197

### Issues Resolved

n/a


### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
