### PR TITLE
Add reply sections to command pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ content/topics/*
 !content/topics/_index.md
 _site
 _data/groups.json
+_data/resp2_replies.json
+_data/resp3_replies.json

--- a/build/init-commands.sh
+++ b/build/init-commands.sh
@@ -46,7 +46,8 @@ done
 
 echo "Command stub files created."
 
-grouppath="../${1}/../groups.json"
-ln -s $grouppath ./_data/groups.json
+for datafile in groups.json resp2_replies.json resp3_replies.json; do
+    ln -s "../${1}/../${datafile}" "./_data/${datafile}"
 
-echo "Created link to groups.json"
+    echo "Created link to ${datafile}"
+done

--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -72,6 +72,29 @@
 <code>ERROR. Command description not loaded</code><br />
 {% endif %}
 
+{% set_global resp2_replies = load_data(path="../_data/resp2_replies.json", required=false) -%}
+{% set_global resp3_replies = load_data(path="../_data/resp3_replies.json", required=false) -%}
+{% if resp2_replies and resp3_replies -%}
+    {% set resp2_reply = resp2_replies | get(key=command_title) | join(sep="\n\n") -%}
+    {% set resp3_reply = resp3_replies | get(key=command_title) | join(sep="\n\n") -%}
+
+    {% if resp2_reply or resp3_reply -%}
+        {% if resp2_reply == resp3_reply -%}
+            <h3>RESP2/RESP3 Reply</h3>
+            {{ commands::fix_links(content=resp2_reply) | markdown | safe }}
+        {% else %}
+            {% if resp2_reply -%}
+                <h3>RESP2 Reply</h3>
+                {{ commands::fix_links(content=resp2_reply) | markdown | safe }}
+            {% endif -%}
+            {% if resp3_reply -%}
+                <h3>RESP3 Reply</h3>
+                {{ commands::fix_links(content=resp3_reply) | markdown | safe }}
+            {% endif -%}
+        {% endif -%}
+    {% endif -%}
+{% endif -%}
+
 {% if command_data_obj and command_data_obj.history %}
 <h3>History</h3>
 <table>


### PR DESCRIPTION
They are built from `resp2_replies.json`/`resp3_replies.json` from valkey-doc. If the RESP2/RESP3 replies are equal, only a single section is added.

Closes #185 

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
