### PR TITLE
Use all caps pure-tokens in command "Usage:"

### DIFF
--- a/templates/macros/command.html
+++ b/templates/macros/command.html
@@ -11,11 +11,11 @@
             {%- set end = "" -%}
         {%- endif -%}
         {%- set token = "" -%}
-        {%- if arguments.type and arguments.type !=  "pure-token" and arguments.token -%}
+        {%- if arguments.type and arguments.token -%}
             {%- set token = arguments.token -%}
         {%- endif -%}
         {%- set name = "" -%}
-        {%- if arguments.type and arguments.type !=  "block"  and arguments.type !=  "oneof" -%}
+        {%- if arguments.type and arguments.type !=  "block"  and arguments.type !=  "oneof" and arguments.type !=  "pure-token" -%}
             {%- set name = arguments.name -%}
         {%- endif -%}
         {%- set next = "" -%}


### PR DESCRIPTION
In the command page's "Usage:", the lower case `name` was used in case of a `pure-token`. However, the all caps `token` should be used instead. For MIGRATE, this makes an even bigger difference (see `empty-string`):

Before:

```
Usage:
    MIGRATE host port 〈 key | empty-string 〉 destination-db timeout [ copy ] [ replace ] [ AUTH auth | AUTH2 username password ] [ KEYS keys ] [ [ KEYS keys ] ... ]
```

Now:

```
Usage:
    MIGRATE host port 〈 key | "" 〉 destination-db timeout [ COPY ] [ REPLACE ] [ AUTH auth | AUTH2 username password ] [ KEYS keys ] [ [ KEYS keys ] ... ]
```

This addresses a part of #116

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
