### PR TITLE
Command pages: Fix the `fix_links` macro

### DIFF
--- a/templates/macros/command.html
+++ b/templates/macros/command.html
@@ -58,5 +58,6 @@
     | regex_replace(pattern=`\]\(\.\./topics/(?P<fname>.*?).md\)`, rep=`](/topics/$fname)`)
     | regex_replace(pattern=`\[(?P<token>.*?)\]:\s+\.\./topics/(?P<fname>.*?).md`, rep=`[$token]: /topics/$fname`)
     | regex_replace(pattern=`\[(?P<token>.*?)\]:\s+(?P<fname>.*?).md`, rep=`[$token]: $fname`)
+    | safe
     }}
 {%- endmacro fix_links -%}


### PR DESCRIPTION
The `fix_links` macro handles markdown strings which do not need HTML escaping. Declaring its template expansion as "safe" prevents double quoting in input like "`<code>`".

This fixes problems when rendering the reply documentation of `CLUSTER INFO`, `GEORADIUS`, and `INFO`.

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
