### PR TITLE
Add a permanent link for slack

### DIFF
--- a/content/connect.md
+++ b/content/connect.md
@@ -10,6 +10,7 @@ You can connect with Valkey in many ways.
 * If you have a **question** about Valkey, head over to the project [GitHub discussions](https://github.com/orgs/valkey-io/discussions) or [Matrix chat](https://matrix.to/#/#valkey:matrix.org).
 * If you’ve found a **bug** in Valkey, file an bug issue on [valkey-io/valkey](https://github.com/valkey-io/valkey/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=%5BBUG%5D)
 * If you want to suggest a **new feature** for Valkey, you feature request issue on [valkey/valkey-io](https://github.com/valkey-io/valkey/issues/new?assignees=&labels=&projects=&template=feature_request.md&title=%5BNEW%5D)
+* If you are interested in becoming a **contributor**, you can connect with other developers on our [slack](https://valkey.io/slack)
 * You can connect on the following **social media** platforms
     * [Valkey on LinkedIn](https://www.linkedin.com/company/valkey/)
     * [Valkey on Twitter](https://twitter.com/valkey_io)

--- a/content/slack.md
+++ b/content/slack.md
@@ -1,0 +1,9 @@
+---
+template: fullwidth.html
+title: Connect to slack
+aliases:
+    - "/slack.html"
+---
+
+Redirecting to slack. If it doesn't happen automatically, click <a href='https://join.slack.com/t/valkey-oss-developer/shared_invite/zt-2nxs51chx-EB9hu9Qdch3GMfRcztTSkQ'>here</a>.
+<meta http-equiv="Refresh" content="0; url='https://join.slack.com/t/valkey-oss-developer/shared_invite/zt-2nxs51chx-EB9hu9Qdch3GMfRcztTSkQ'" />


### PR DESCRIPTION
### Description

Our slack was not publicly visible, and I'm not convinced the link will be permanent. So add a redirect link on our page that you can use to join the slack that will be permanent. 
 
### Issues Resolved

Hopefully addresses https://github.com/valkey-io/valkey-io.github.io/issues/198.

### Check List
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
