### PR TITLE
Add more artifacts on the downloads page

### DIFF
--- a/content/download/releases/v7-2-5.md
+++ b/content/download/releases/v7-2-5.md
@@ -24,10 +24,6 @@ extra:
             name: EPEL
             id: 'valkey'
     artifacts:
-        -   distro: bionic
-            arch: 
-                -   arm64
-                -   x86_64
         -   distro: focal
             arch:
                 -   arm64

--- a/content/download/releases/v7-2-5.md
+++ b/content/download/releases/v7-2-5.md
@@ -32,6 +32,13 @@ extra:
             arch:
                 -   arm64
                 -   x86_64
+        -   distro: jammy
+            arch:
+                -   arm64
+                -   x86_64
+        -   distro: noble
+            arch:
+                -   x86_64
 ---
 
 Valkey 7.2.5 Release

--- a/content/download/releases/v7-2-6.md
+++ b/content/download/releases/v7-2-6.md
@@ -24,10 +24,6 @@ extra:
             name: EPEL
             id: 'valkey'
     artifacts:
-        -   distro: bionic
-            arch: 
-                -   arm64
-                -   x86_64
         -   distro: focal
             arch:
                 -   arm64

--- a/content/download/releases/v7-2-6.md
+++ b/content/download/releases/v7-2-6.md
@@ -32,6 +32,13 @@ extra:
             arch:
                 -   arm64
                 -   x86_64
+        -   distro: jammy
+            arch:
+                -   arm64
+                -   x86_64
+        -   distro: noble
+            arch:
+                -   x86_64
 ---
 
 Valkey 7.2.6 Release

--- a/content/download/releases/v7-2-7.md
+++ b/content/download/releases/v7-2-7.md
@@ -24,10 +24,6 @@ extra:
             name: EPEL
             id: 'valkey'
     artifacts:
-        -   distro: bionic
-            arch: 
-                -   arm64
-                -   x86_64
         -   distro: focal
             arch:
                 -   arm64

--- a/content/download/releases/v7-2-7.md
+++ b/content/download/releases/v7-2-7.md
@@ -32,6 +32,13 @@ extra:
             arch:
                 -   arm64
                 -   x86_64
+        -   distro: jammy
+            arch:
+                -   arm64
+                -   x86_64
+        -   distro: noble
+            arch:
+                -   x86_64
 ---
 
 Valkey 7.2.7 Release

--- a/content/download/releases/v7-2-8.md
+++ b/content/download/releases/v7-2-8.md
@@ -26,6 +26,12 @@ extra:
             arch:
                 -   arm64
                 -   x86_64
+        -   distro: jammy
+            arch:
+                -   x86_64
+        -   distro: noble
+            arch:
+                -   x86_64
 ---
 
 Valkey 7.2.8 Release

--- a/content/download/releases/v7-2-8.md
+++ b/content/download/releases/v7-2-8.md
@@ -18,10 +18,6 @@ extra:
     packages:
 
     artifacts:
-        -   distro: bionic
-            arch: 
-                -   arm64
-                -   x86_64
         -   distro: focal
             arch:
                 -   arm64

--- a/content/download/releases/v8-0-0.md
+++ b/content/download/releases/v8-0-0.md
@@ -26,6 +26,13 @@ extra:
             arch:
                 -   arm64
                 -   x86_64
+        -   distro: jammy
+            arch:
+                -   arm64
+                -   x86_64
+        -   distro: noble
+            arch:
+                -   x86_64
 ---
 
 Valkey 8.0.0 Release

--- a/content/download/releases/v8-0-0.md
+++ b/content/download/releases/v8-0-0.md
@@ -18,10 +18,6 @@ extra:
     packages:
 
     artifacts:
-        -   distro: bionic
-            arch: 
-                -   arm64
-                -   x86_64
         -   distro: focal
             arch:
                 -   arm64

--- a/content/download/releases/v8-0-1.md
+++ b/content/download/releases/v8-0-1.md
@@ -26,6 +26,13 @@ extra:
             arch:
                 -   arm64
                 -   x86_64
+        -   distro: jammy
+            arch:
+                -   arm64
+                -   x86_64
+        -   distro: noble
+            arch:
+                -   x86_64
 ---
 
 Valkey 8.0.1 Release

--- a/content/download/releases/v8-0-1.md
+++ b/content/download/releases/v8-0-1.md
@@ -18,10 +18,6 @@ extra:
     packages:
 
     artifacts:
-        -   distro: bionic
-            arch: 
-                -   arm64
-                -   x86_64
         -   distro: focal
             arch:
                 -   arm64

--- a/content/download/releases/v8-0-2.md
+++ b/content/download/releases/v8-0-2.md
@@ -18,10 +18,6 @@ extra:
     packages:
 
     artifacts:
-        -   distro: bionic
-            arch: 
-                -   arm64
-                -   x86_64
         -   distro: focal
             arch:
                 -   arm64


### PR DESCRIPTION
### Description
Adds links to more artifacts that were build for valkey for ubuntu 22 and 24

Crosschecked all the binaries that are present on the production S3 bucket for artifacts.
<!-- Describe what this change achieves-->
 
### Issues Resolved
closes #206 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
