### PR TITLE
Automatically deploy website on updates to main

### DIFF
--- a/.github/workflows/zola-deploy.yml
+++ b/.github/workflows/zola-deploy.yml
@@ -1,8 +1,8 @@
-name: Zola on GitHub Pages
+name: Deploy website
 
 on:
   push:
-    branches: ["prod_zola"]
+    branches: ["main"]
   
   workflow_dispatch:
 
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout prod
         uses: actions/checkout@v4
         with:
-          ref: prod_zola
+          ref: main
           path: website
 
       - name: Checkout valkey-doc


### PR DESCRIPTION
### Description

Automatically deploy the website when we update main, instead of having to merge it to Zola.
 
### Issues Resolved

No issue, but discussed it offline.

### Check List
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
