### PR TITLE
Skip release candidates when on downloads page

### DIFF
--- a/templates/download.html
+++ b/templates/download.html
@@ -6,7 +6,16 @@
 {% block main_content %}
 
 {% set release_section = get_section(path="download/releases/_index.md") %}
-{% set most_recent_release_page = release_section.pages | reverse | slice(end= 1) %}
+{% set releases = release_section.pages | reverse %}
+
+{% set_global active_releases = [] %}
+{% for release in releases %}
+    {% if release.extra.tag is not matching(".*-.*") %}
+        {% set_global active_releases = active_releases | concat(with=release) %}
+    {% endif %}
+{% endfor %}
+
+{% set most_recent_release_page = active_releases | slice(end= 1) %}
 {% set release_date = most_recent_release_page[0].date %}
 {% set release = most_recent_release_page[0].extra %}
 
@@ -26,7 +35,7 @@ The <a href="./releases/">releases</a> page contains links to download all curre
 
 <h2> Latest supported version of past releases</h2>
 
-{% for older_release in release_section.pages | reverse %}
+{% for older_release in active_releases %}
     {% set older_split_ver = older_release.extra.tag | split(pat=".")%}
     {% set older_major = older_split_ver | nth(n= 0) %}
     {% if older_major != major %}

--- a/templates/release-section.html
+++ b/templates/release-section.html
@@ -14,20 +14,22 @@
     {% set major = split_ver | nth(n= 0) %}
     {% set minor = split_ver | nth(n= 1) %}
     {% set patch = split_ver | nth(n= 2) %}
+    {% set header =  major ~ "." ~ minor %}
 
-
-    {% set_global release_lines = release_lines | concat(with=major) %}
+    {% set_global release_lines = release_lines | concat(with=header) %}
 {% endfor %}
 
 {% set release_lines_unique = release_lines | unique %}
 {% for line in release_lines_unique %}
-    <h2>{{ line }}.x.x</h2>
+    <h2>{{ line }}.x</h2>
     <ul>
     {% for release in section.pages | reverse %}
         {% set split_ver = release.extra.tag | split(pat=".")%}
         {% set major = split_ver | nth(n= 0) %}
+        {% set minor = split_ver | nth(n= 1) %}
+        {% set header =  major ~ "." ~ minor %}
 
-        {% if major == line %}
+        {% if header == line %}
             <li><a href="{{ release.permalink }}"> {{ release.extra.tag }}</a> <small>(Released {{ release.date | date(format="%Y-%m-%d") }})</small></li>
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
### Description

For 8.0, we didn't have the release candidates on the release page, which I think was a miss. This new version now shows each major/minor pair on the all releases page and in addition also only shows the non-rc candidate versions on the downloads page.
 
### Issues Resolved

<!-- List any issues this PR will resolve. -->
<!-- Example: closes #1234 -->

### Check List
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
