### PR TITLE
Add command search to the command reference page

### DIFF
--- a/templates/commands.html
+++ b/templates/commands.html
@@ -10,6 +10,11 @@
 {% set_global group_descriptions = load_data(path= "../_data/groups.json", required= false) %}
 
 {% set commands_entries = [] %}
+<!-- command search box -->
+<div class="search-container">
+    <input type="text" id="search-box" placeholder="Search commands..." onkeyup="searchCommands()" />
+</div>
+
 {% for page in section.pages %}
     {% set command_data = load_data(path= commands::command_json_path(slug= page.slug), required= false) %}
     {% if command_data %}
@@ -48,6 +53,61 @@
     </div>
     </div>
 {% endfor %}
+
+<script>
+function searchCommands() {
+    var input = document.getElementById("search-box").value.toLowerCase();
+    var groups = document.querySelectorAll(".command-group");
+
+    groups.forEach(function (group) {
+        var items = group.querySelectorAll(".command-entry");
+        var found = false;
+        items.forEach(function (item) {
+            var text = item.querySelector("a").innerText.toLowerCase();
+            if (text.includes(input)) {
+                item.style.display = "";
+                found = true;
+            } else {
+                item.style.display = "none";
+            }
+        });
+        group.style.display = found ? "" : "none";
+    });
+}
+</script>
+
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+    document.getElementById("search-box").focus();
+});
+</script>
+
+<style>
+.search-container {
+    margin: 20px 0;
+    text-align: center;
+}
+
+#search-box {
+    width: 60%;
+    padding: 10px;
+    font-size: 16px;
+    border: 2px solid #ddd;
+    border-radius: 4px;
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+#search-box:focus {
+    border-color: #007bff;
+    box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+}
+
+#search-box::placeholder {
+    color: #aaa;
+    font-style: italic;
+}
+</style>
 
 {% endblock main_content %}
 


### PR DESCRIPTION
- Added a search box for filtering commands dynamically.
- Implemented JavaScript for search functionality.
- Styled the search input for better UX.

Enhances usability by allowing users to quickly locate commands.

### Description

Added this:
![image](https://github.com/user-attachments/assets/bbe784a1-5c73-468b-a53e-259e64e8713b)

 
### Issues Resolved
https://github.com/valkey-io/valkey-io.github.io/issues/215

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
