### PR TITLE
Correct versions on download page and template correction

### DIFF
--- a/content/download/releases/v8-0-0.md
+++ b/content/download/releases/v8-0-0.md
@@ -18,6 +18,10 @@ extra:
     packages:
 
     artifacts:
+        -   distro: bionic
+            arch:
+                -   arm64
+                -   x86_64
         -   distro: focal
             arch:
                 -   arm64

--- a/content/download/releases/v8-0-1.md
+++ b/content/download/releases/v8-0-1.md
@@ -18,6 +18,10 @@ extra:
     packages:
 
     artifacts:
+        -   distro: bionic
+            arch:
+                -   arm64
+                -   x86_64
         -   distro: focal
             arch:
                 -   arm64

--- a/content/download/releases/v8-0-2.md
+++ b/content/download/releases/v8-0-2.md
@@ -18,6 +18,10 @@ extra:
     packages:
 
     artifacts:
+        -   distro: bionic
+            arch:
+                -   arm64
+                -   x86_64
         -   distro: focal
             arch:
                 -   arm64

--- a/content/download/releases/v8-1-0.md
+++ b/content/download/releases/v8-1-0.md
@@ -20,7 +20,6 @@ extra:
     artifacts:
         -   distro: focal
             arch:
-                -   arm64
                 -   x86_64
         -   distro: jammy
             arch:
@@ -29,6 +28,7 @@ extra:
         -   distro: noble
             arch:
                 -   x86_64
+                -   arm64
 ---
 
 Valkey 8.1.0-ga Release

--- a/templates/valkey-website-template.md
+++ b/templates/valkey-website-template.md
@@ -15,16 +15,13 @@ extra:
     packages:
 
     artifacts:
-        -   distro: focal
-            arch:
-                -   arm64
-                -   x86_64
         -   distro: jammy
             arch:
                 -   arm64
                 -   x86_64
         -   distro: noble
             arch:
+                -   arm64
                 -   x86_64
 ---
 


### PR DESCRIPTION
### Description

downloads page did not show the correct version which were available.
Also corrects the template that will be used by the automation.

We are discontinuing the focal support as it s EOL

> Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
