### PR TITLE
Bug fix: allow local builds without requiring client directory

### DIFF
--- a/templates/client-list.html
+++ b/templates/client-list.html
@@ -2,68 +2,74 @@
 {% import "macros/docs.html" as docs %}
 
 {% block main_content %}
-    <div class="markdown-content">
-        {% set content_parts = section.content | split(pat="<!-- split -->") %}
-        {{ content_parts[0] | markdown | safe }}
-    </div>
+    {% set client_path = section.extra.recommended_clients_paths | first %}
+    {% set client = load_data(path = docs::client_json_path(client_path=client_path), format="json", required = false) %}
+    {% if not client %}
+        <strong>Clients page not found.</strong> You likely need to build the client page. See "Building additional content" in the README.md file.
+    {% else %}
+        <div class="markdown-content">
+            {% set content_parts = section.content | split(pat="<!-- split -->") %}
+            {{ content_parts[0] | markdown | safe }}
+        </div>
 
-    <div class="client-list">
-        <h2>Table of Contents</h2>
-        <ul>              
-            {% set languages = [] %}
-            {% for path in section.extra.recommended_clients_paths %}
-                {% set language = path | split(pat="/") | nth(n=1) %}
-                {% if language not in languages %}
-                    {% set_global languages = languages | concat(with=language) %}
-                {% endif %}
-            {% endfor %}
-            {% for language in languages %}
-                <li><a href="#{{ language | slugify }}">{{ docs::format_language(language=language) }}</a></li>
-            {% endfor %}
-            <li><a href="#feature-comparison-table">Feature Comparison Table</a></li>
-        </ul>
-        {% for language in languages %}
-            <div class="language-clients">
-                <h2 id="{{ language | slugify }}">{{ docs::format_language(language=language) }}</h2>
+        <div class="client-list">
+            <h2>Table of Contents</h2>
+            <ul>              
+                {% set languages = [] %}
                 {% for path in section.extra.recommended_clients_paths %}
-                    {% set client = load_data(path = docs::client_json_path(client_path= path), format="json") %}
-                    {% if client.language == language %}
-                    <div class="client-item" >
-                        <h3 id="{{ client.name | slugify }}">{{ client.name }}</h3>
-                        <ul>
-                            <li><strong>Repo:</strong> <a href="{{ client.repo }}">{{ client.name }}</a></li>
-                            <li>
-                                <strong>Installation:</strong>
-                                {% if client.installation is iterable %}
-                                    <ul>
-                                        {% for installation_type in client.installation %}
-                                            <li>
-                                                {{ installation_type.type }}:
-                                                <pre>{{ installation_type.command }}</pre>
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                {% else %}
-                                    <code>{{ client.installation }}</code>
-                                {% endif %}
-                            </li>
-                            <li><strong>Version:</strong> {{ client.version }}</li>
-                            <li><strong>Version Released:</strong> {{ client.version_released }}</li>
-                            <li><strong>Description:</strong> {{ client.description }}</li>
-                            <li><strong>License:</strong> {{ client.license }}</li>
-                        </ul>
-                    </div>                    
+                    {% set language = path | split(pat="/") | nth(n=1) %}
+                    {% if language not in languages %}
+                        {% set_global languages = languages | concat(with=language) %}
                     {% endif %}
                 {% endfor %}
-            </div>
-        {% endfor %}
-    </div>
-    <div class="markdown-content">
-        {{ content_parts[1] | markdown | safe }}
-    </div>
-    <div  id="feature-comparison-table" class = "feature-comparison-table" >
-        {% set client_paths = section.extra.recommended_clients_paths %}
-        {% set client_fields = section.extra.client_fields %}
-        {% include "client-feature-table.html" %}
-    </div>
+                {% for language in languages %}
+                    <li><a href="#{{ language | slugify }}">{{ docs::format_language(language=language) }}</a></li>
+                {% endfor %}
+                <li><a href="#feature-comparison-table">Feature Comparison Table</a></li>
+            </ul>
+            {% for language in languages %}
+                <div class="language-clients">
+                    <h2 id="{{ language | slugify }}">{{ docs::format_language(language=language) }}</h2>
+                    {% for path in section.extra.recommended_clients_paths %}
+                        {% set client = load_data(path = docs::client_json_path(client_path= path), format="json") %}
+                        {% if client.language == language %}
+                        <div class="client-item" >
+                            <h3 id="{{ client.name | slugify }}">{{ client.name }}</h3>
+                            <ul>
+                                <li><strong>Repo:</strong> <a href="{{ client.repo }}">{{ client.name }}</a></li>
+                                <li>
+                                    <strong>Installation:</strong>
+                                    {% if client.installation is iterable %}
+                                        <ul>
+                                            {% for installation_type in client.installation %}
+                                                <li>
+                                                    {{ installation_type.type }}:
+                                                    <pre>{{ installation_type.command }}</pre>
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% else %}
+                                        <code>{{ client.installation }}</code>
+                                    {% endif %}
+                                </li>
+                                <li><strong>Version:</strong> {{ client.version }}</li>
+                                <li><strong>Version Released:</strong> {{ client.version_released }}</li>
+                                <li><strong>Description:</strong> {{ client.description }}</li>
+                                <li><strong>License:</strong> {{ client.license }}</li>
+                            </ul>
+                        </div>                    
+                        {% endif %}
+                    {% endfor %}
+                </div>
+            {% endfor %}
+        </div>
+        <div class="markdown-content">
+            {{ content_parts[1] | markdown | safe }}
+        </div>
+        <div  id="feature-comparison-table" class = "feature-comparison-table" >
+            {% set client_paths = section.extra.recommended_clients_paths %}
+            {% set client_fields = section.extra.client_fields %}
+            {% include "client-feature-table.html" %}
+        </div>
+    {% endif %}
 {% endblock main_content %}


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Currently building the zola site locally is not possible when the clients directory is not built, as the `zola serve` command fails.
This is fixed by introducing an additional boolean variable `clients_built` in the client's page frontmatter, which is set to false by default, but updates to be true when running the `init_topics_and_clients.sh` script successfully. The page loads only if this var is set to true, otherwise a "Clients page not found" message is displayed, similar to the behavior in the commands and topics documentation.
 
### Issues Resolved

<!-- List any issues this PR will resolve. -->
<!-- Example: closes #1234 -->

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
