### PR TITLE
Bug fix: improve responsive layout of homepage documentation tiles

### DIFF
--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -1073,6 +1073,19 @@ pre table {
 
 .documentation-card-grid {
   margin-top: 4rem;
+
+  @media (max-width: 1100px) {
+    .col {
+      flex: 1 1 50%;
+      margin-bottom: 3rem;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .col {
+      flex: 1 1 100%;
+    }
+  }
 }
 
 .documentation-card {
@@ -1083,10 +1096,8 @@ pre table {
   border-radius: 20px;
   color: white;
   background: #2d2471;
-  margin-bottom: 3rem;
 
   @include respond-min(768px) {
-    margin-bottom: 0;
     min-height: 100%;
   }
 


### PR DESCRIPTION
The documentation tiles on the homepage were stacking awkwardly at screen widths between 768px and 1090px. Modified the grid layout to create a more natural 2x2 layout at these intermediate screen sizes, ensuring consistent spacing and better visual organization.

<img width="1023" alt="Screenshot 2025-04-24 at 4 53 59 PM" src="https://github.com/user-attachments/assets/237bce45-1cec-46ad-925a-766d0627fd93" />

<img width="480" alt="Screenshot 2025-04-24 at 4 54 13 PM" src="https://github.com/user-attachments/assets/ee8e564a-44d1-45f4-914b-248787ae9340" />
