### PR TITLE
Adding an ACL section for each command on their command page

### DIFF
--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -78,6 +78,16 @@
         <dd>{{ command_data_obj.since }}</dd>
     <dl>
     {% endif %}
+    {% if command_data_obj.acl_categories %}
+    <dl>
+        <dt>ACL Categories:</dt>
+        <dd>        
+            {% for category in command_data_obj.acl_categories %}
+            @{{ category|lower }}{% if not loop.last %}, {% endif %}
+            {% endfor %}
+        </dd>
+    <dl>
+    {% endif %}
     </dl>
 
 {% else %}


### PR DESCRIPTION
### Description

This will add a section underneath the since on command pages to include ACL categories. This will add an @ in front of each category a comma inbetween and will set as lowercase.
## Pictures of changes:
#### Single acl category:
![image](https://github.com/user-attachments/assets/45f87476-1286-44fb-a21b-56cae2dc782d)

#### Works with module commands as well:
![image](https://github.com/user-attachments/assets/0092ddca-346d-4f06-a88a-d5bf75850ebe)


As mentioned in the issue, non module commands only have their data type in the ACL categories. If this is a blocking issue I can see about adding all acl categories to the command pages for commands

### Issues Resolved

This is based off of https://github.com/valkey-io/valkey-doc/issues/272 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
