### PR TITLE
Adding implicit ACL categories to be displayed on website

### DIFF
--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -78,12 +78,54 @@
         <dd>{{ command_data_obj.since }}</dd>
     <dl>
     {% endif %}
-    {% if command_data_obj.acl_categories %}
+    {% if command_data_obj.acl_categories or command_data_obj.command_flags %}
     <dl>
         <dt>ACL Categories:</dt>
-        <dd>        
-            {% for category in command_data_obj.acl_categories %}
-            @{{ category|lower }}{% if not loop.last %}, {% endif %}
+        <dd>
+            {% set all_categories = [] %}
+            
+            {% if command_data_obj.acl_categories %}
+                {% set all_categories = command_data_obj.acl_categories %}
+            {% endif %}
+            
+            {% if command_data_obj.command_flags %}
+                {# Command flag WRITE implies ACL category WRITE #}
+                {% if "WRITE" in command_data_obj.command_flags %}
+                    {% set all_categories = all_categories | concat(with="WRITE") %}
+                {% endif %}
+
+                {# Command flag READONLY and not ACL category SCRIPTING implies ACL category READ #}
+                {% if "READONLY" in command_data_obj.command_flags and (not command_data_obj.acl_categories or not "SCRIPTING" in command_data_obj.acl_categories) %}
+                    {% set all_categories = all_categories | concat(with="READ") %}
+                {% endif %}
+
+                {# Command flag ADMIN implies ACL categories ADMIN and DANGEROUS #}
+                {% if "ADMIN" in command_data_obj.command_flags %}
+                    {% set all_categories = all_categories | concat(with="ADMIN") | concat(with="DANGEROUS") %}
+                {% endif %}
+
+                {% if "FAST" in command_data_obj.command_flags %}
+                    {% set all_categories = all_categories | concat(with="FAST") %}
+                {% endif %}
+
+                {# Command flag PUBSUB implies ACL category PUBSUB #}
+                {% if "PUBSUB" in command_data_obj.command_flags %}
+                    {% set all_categories = all_categories | concat(with="PUBSUB") %}
+                {% endif %}
+
+                {# Command flag BLOCKING implies ACL category BLOCKING #}
+                {% if "BLOCKING" in command_data_obj.command_flags %}
+                    {% set all_categories = all_categories | concat(with="BLOCKING") %}
+                {% endif %}
+            {% endif %}
+
+            {# Not ACL category FAST implies ACL category SLOW. "If it's not fast, it's slow." #}
+            {% if "FAST" not in all_categories %}
+                {% set all_categories = all_categories | concat(with="SLOW") %}
+            {% endif %}
+
+            {% for category in all_categories %}
+                @{{ category|lower }}{% if not loop.last %}, {% endif %}
             {% endfor %}
         </dd>
     <dl>


### PR DESCRIPTION
### Description

Currently implicit categories aren't shown on the website. This pr parses the command flags and adds the implicit categories based on this
Example images
![image](https://github.com/user-attachments/assets/26c29d51-4259-41bc-ab0f-61e03702c43d)
![image](https://github.com/user-attachments/assets/8fa6cfe2-a257-48bb-ac8c-ced4b1c1b7f1)
![image](https://github.com/user-attachments/assets/70284ade-63dc-401e-b332-d1847ddc305b)


If more screenshots are needed I can add to display all categories.

### Issues Resolved

This will fully finish https://github.com/valkey-io/valkey-doc/issues/272#issuecomment-2864287464

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
