### PR TITLE
Added valkey-search support

### DIFF
--- a/.github/workflows/zola-deploy.yml
+++ b/.github/workflows/zola-deploy.yml
@@ -40,6 +40,12 @@ jobs:
             repository: valkey-io/valkey-bloom
             path: valkey-bloom
 
+      - name: Checkout valkey-search
+        uses: actions/checkout@v4
+        with:
+            repository: valkey-io/valkey-search
+            path: valkey-search
+
       - name: Checkout valkey-json
         uses: actions/checkout@v4
         with:
@@ -50,7 +56,7 @@ jobs:
         run: |
           cd website
           ./build/init-topics-and-clients.sh ../valkey-doc/topics ../valkey-doc/clients
-          ./build/init-commands.sh ../valkey-doc/commands ../valkey/src/commands ../valkey-bloom/src/commands ../valkey-json/src/commands
+          ./build/init-commands.sh ../valkey-doc/commands ../valkey/src/commands ../valkey-bloom/src/commands ../valkey-json/src/commands ../valkey-search/src/commands
 
       - name: Build only
         uses: shalzz/zola-deploy-action@v0.19.1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Valkey.io website
 
 This repo contains the source for the valkey.io website (build scripts, template, blog posts, stylesheets, etc.).
-The build integrates content from [`valkey-io/valkey-doc`](https://github.com/valkey-io/valkey-doc) and the commands definitions from [`valkey-io/valkey`](https://github.com/valkey-io/valkey), [`valkey-io/valkey-bloom`](https://github.com/valkey-io/valkey-bloom), and [`valkey-io/valkey-json`](https://github.com/valkey-io/valkey-json) (see [Build Locally](#build-locally) below for more details) 
+The build integrates content from [`valkey-io/valkey-doc`](https://github.com/valkey-io/valkey-doc) and the commands definitions from [`valkey-io/valkey`](https://github.com/valkey-io/valkey), [`valkey-io/valkey-bloom`](https://github.com/valkey-io/valkey-bloom), and [`valkey-io/valkey-json`](https://github.com/valkey-io/valkey-json) (see [Build Locally](#build-locally) below for more details)
 
 ## Contributing
 
@@ -29,7 +29,7 @@ Changes to external content (command reference, documentation topics) require a 
 ## Building additional content
 
 **By default, the site will build without documentation topics, command reference, or the clients page.**
-The content for documentation topics and the clients page are stored within the `valkey-io/valkey-doc` repo. 
+The content for documentation topics and the clients page are stored within the `valkey-io/valkey-doc` repo.
 The content for the command reference page is in the `valkey-io/valkey` repo.
 
 If you want to build the site with this content, you'll need to have a local copy of `valkey-io/valkey-doc` and `valkey-io/valkey` _outside_ of this repo.
@@ -64,7 +64,8 @@ Commit your changes to your local copy of `valkey-io/valkey-doc`.
 ### Building the command reference
 
 The command reference (i.e. `/commands/set/`, `/commands/get/`, `/commands/lolwut/`) sources information from `valkey-io/valkey`, `valkey-io/valkey-bloom`, and `valkey-io/valkey-doc`.
-`valkey-io/valkey`, `valkey-io/valkey-bloom` and `valkey-io/valkey-json` provides the command metadata (items like computational complexity, version history, arguments, etc) whilst `valkey-io/valkey-doc` provides the command description and the command reply.
+`valkey-io/valkey`, `valkey-io/valkey-bloom`, `valkey-io/valkey-json` and `valkey-io/valkey-search` provides the command metadata (items like computational complexity, version history, arguments, etc)
+whilst `valkey-io/valkey-doc` provides the command description and the command reply.
 
 ```mermaid
 flowchart TD
@@ -75,13 +76,16 @@ flowchart TD
     H --> J[Files: /resp2_replies.json,<br/>/resp3_replies.json] --> Z[Command Reply]
 ```
 
-Let's say that this repo and your local copy of `valkey-io/valkey-doc`, `valkey-io/valkey-bloom`, `valkey-io/valkey-json`, and `valkey-io/valkey` reside in the same directories.
+Let's say that this repo and your local copy of `valkey-io/valkey-doc`, `valkey-io/valkey-bloom`, `valkey-io/valkey-json`, `valkey-io/valkey-search`
+and `valkey-io/valkey` reside in the same directories.
+
 First, stop the `zola serve` process if you're running it.
 From the root directory of this repo run:
 
 ```shell
 # You should only need to run this once or when you add a new command.
-./build/init-commands.sh ../valkey-doc/commands ../valkey/src/commands ../valkey-bloom/src/commands ../valkey-json/src/commands
+./build/init-commands.sh ../valkey-doc/commands ../valkey/src/commands \
+    ../valkey-bloom/src/commands ../valkey-json/src/commands ../valkey-search/src/commands
 ```
 
 Then, restart Zola.

--- a/build/init-commands.sh
+++ b/build/init-commands.sh
@@ -4,16 +4,16 @@
 
 # first check to make sure there are arguments
 if [ -z "$1" ]; then
-    echo "You must supply a path to the command docs as the first argument" 
-    exit 1
-fi 
-
-if [ -z "$2" ]; then
-    echo "You must supply a path to the command json as the second argument" 
+    echo "You must supply a path to the command docs as the first argument"
     exit 1
 fi
 
-# check for validity of these agruments as paths
+if [ -z "$2" ]; then
+    echo "You must supply a path to the command json as the second argument"
+    exit 1
+fi
+
+# check for validity of these arguments as paths
 if [ ! -d "$1" ]; then
     echo "The command doc directory must exist and be a valid path"
     exit 1
@@ -34,22 +34,31 @@ if [ ! -d "$4" ]; then
     exit 1
 fi
 
+if [ ! -d "$5" ]; then
+    echo "The Search module command JSON directory must exist and be a valid path"
+    exit 1
+fi
+
 ln -s $1 ./build-command-docs
 ln -s $2 ./build-command-json
 ln -s $3 ./build-bloom-command-json
 ln -s $4 ./build-json-command-json
+ln -s $5 ./build-search-command-json
+
 for fname in $(find $1 -maxdepth 1  -iname "*.md")
 do
     base=${fname##*/}
     command=${base%.*}
     command_upper=$(awk '{ print toupper($0) }' <<< $command)
-    if [[ "$command" != "index" ]]; then 
+    if [[ "$command" != "index" ]]; then
         if [ -f "$2/$command.json" ]; then
             metadata_path="/commands/$command.json in the 'valkey' repo"
         elif [ -f "$3/$command.json" ]; then
             metadata_path="/commands/$command.json in the 'valkey-bloom' repo"
         elif [ -f "$4/$command.json" ]; then
             metadata_path="/commands/$command.json in the 'valkey-json' repo"
+        elif [ -f "$5/$command.json" ]; then
+            metadata_path="/commands/$command.json in the 'valkey-search' repo"
         fi
         cat << EOF > "./content/commands/$command.md"
 +++

--- a/build/init-topics-and-clients.sh
+++ b/build/init-topics-and-clients.sh
@@ -4,16 +4,16 @@
 
 # first check to make sure there are arguments
 if [ -z "$1" ]; then
-    echo "You must supply a path to the topics as the first argument" 
+    echo "You must supply a path to the topics as the first argument"
     exit 1
-fi 
+fi
 
 if [ -z "$2" ]; then
-    echo "You must supply a path to the clients directory as the first argument" 
+    echo "You must supply a path to the clients directory as the second argument"
     exit 1
-fi 
+fi
 
-# check for validity of these agruments as paths
+# check for validity of these arguments as paths
 if [ ! -d "$1" ]; then
     echo "The topics directory must exist and be a valid path"
     exit 1

--- a/config.toml
+++ b/config.toml
@@ -23,6 +23,7 @@ command_description_path = "../build-command-docs/"
 command_json_path = "../build-command-json/"
 command_bloom_json_path = "../build-bloom-command-json/"
 command_json_json_path = "../build-json-command-json/"
+command_search_json_path = "../build-search-command-json/"
 client_json_path = "../build-clients/"
 doc_topic_path = "../build-topics/"
 

--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -10,14 +10,15 @@
 {% set command_sources = [
     load_data(path= commands::command_json_path(slug= page.slug), required= false),
     load_data(path= commands::command_bloom_json_path(slug= page.slug), required= false),
-    load_data(path= commands::command_json_json_path(slug= page.slug), required= false)
+    load_data(path= commands::command_json_json_path(slug= page.slug), required= false),
+    load_data(path= commands::command_search_json_path(slug= page.slug), required= false)
 ] %}
 
 {% set command_data = command_sources | filter(attribute="") | first %}
 
 {% if command_data %}
     {% set command_obj_name = commands::command_obj_name(command_data= command_data) %}
-    {% set command_data_obj = command_data[command_obj_name] %} 
+    {% set command_data_obj = command_data[command_obj_name] %}
     {% if command_data_obj.container %}
         {% set command_title =  command_data_obj.container  ~ " " ~ command_obj_name %}
     {% else %}
@@ -57,7 +58,7 @@
     {% endif %}
     {% if command_data_obj.module_since %}
     <dl>
-        {% if "bf." in page.slug  %} 
+        {% if "bf." in page.slug  %}
             {% set module_reply = load_data(path="../_data/modules.json", required=false) -%}
             <dt>Module:</dt>
             <dd><a href={{module_reply.valkey_bloom.repo}}>{{module_reply.valkey_bloom.name}}</a></dd>
@@ -65,6 +66,10 @@
             {% set module_reply = load_data(path="../_data/modules.json", required=false) -%}
             <dt>Module:</dt>
             <dd><a href={{module_reply.valkey_json.repo}}>{{module_reply.valkey_json.name}}</a></dd>
+        {% elif "ft." in page.slug %}
+            {% set module_reply = load_data(path="../_data/modules.json", required=false) -%}
+            <dt>Module:</dt>
+            <dd><a href={{module_reply.valkey_search.repo}}>{{module_reply.valkey_search.name}}</a></dd>
         {% endif %}
     <dl>
     <dl>
@@ -81,7 +86,7 @@
     {% if command_data_obj.acl_categories %}
     <dl>
         <dt>ACL Categories:</dt>
-        <dd>        
+        <dd>
             {% for category in command_data_obj.acl_categories %}
             @{{ category|lower }}{% if not loop.last %}, {% endif %}
             {% endfor %}
@@ -146,7 +151,7 @@
             <td>{{ entry[1] | markdown | safe}}</td>
         </tr>
         {% endfor %}
-    
+
     </tbody>
 </table>
 {% endif %}

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -27,7 +27,8 @@
     {% for json_path in [
         commands::command_json_path(slug=page.slug),
         commands::command_bloom_json_path(slug=page.slug),
-        commands::command_json_json_path(slug=page.slug)
+        commands::command_json_json_path(slug=page.slug),
+        commands::command_search_json_path(slug=page.slug)
     ] %}
         {% set command_data = load_data(path= json_path, required= false) %}
         {% if command_data %}
@@ -39,7 +40,7 @@
             {% endif %}
             {% set command_entry = [
                 command_display,
-                page.permalink | safe, 
+                page.permalink | safe,
                 command_data_obj.summary,
                 command_data_obj.group
             ] %}

--- a/templates/macros/command.html
+++ b/templates/macros/command.html
@@ -48,17 +48,21 @@
 {{ command_obj_name }}
 {%- endmacro command_obj_name -%}
 
+{%- macro command_search_json_path(slug) -%}
+{{config.extra.command_search_json_path }}{{ slug }}.json
+{%- endmacro command_search_json_path -%}
+
 {%- macro command_json_path(slug) -%}
 {{config.extra.command_json_path }}{{ slug }}.json
-{%- endmacro load_command_json -%}
+{%- endmacro command_json_path -%}
 
 {%- macro command_bloom_json_path(slug) -%}
 {{config.extra.command_bloom_json_path }}{{ slug }}.json
-{%- endmacro load_bloom_command_json -%}
+{%- endmacro command_bloom_json_path -%}
 
 {%- macro command_json_json_path(slug) -%}
 {{config.extra.command_json_json_path }}{{ slug }}.json
-{%- endmacro load_json_command_json -%}
+{%- endmacro command_json_json_path -%}
 
 {%- macro fix_links(content) -%}
 {{ content


### PR DESCRIPTION
With this PR, I have added support for `valkey-search` website content (topic + commands reference).

Related PR (man pages):
https://github.com/valkey-io/valkey-doc/pull/275

<img width="1918" alt="Screenshot 2025-05-14 at 19 19 15" src="https://github.com/user-attachments/assets/23d1ee8b-262f-498e-949e-9e30b9b8ccb4" />
<img width="1797" alt="Screenshot 2025-05-14 at 19 18 40" src="https://github.com/user-attachments/assets/36618369-ec1d-441d-bb70-1916c493a491" />
