### PR TITLE
Add redisson as a client that supports Valkey

### DIFF
--- a/content/clients/_index.md
+++ b/content/clients/_index.md
@@ -9,6 +9,7 @@ recommended_clients_paths = [
     "/node.js/iovalkey.json",
     "/java/valkey-GLIDE.json",
     "/java/valkey-java.json",
+    "/java/redisson.json",
     "/go/valkey-GLIDE.json",
     "/go/valkey-go.json",
     "/php/phpredis.json",


### PR DESCRIPTION
See latest update here: https://github.com/valkey-io/valkey-doc/pull/283

### Description

Add redisson as a client that supports Valkey. Also removes some extra invisible white space.
 
### Issues Resolved

No issue

### Check List
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
