### PR TITLE
Bug fix: standardize page content width alignment with header

### DIFF
--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -451,9 +451,11 @@ p {
 }
 
 .left-aside {
-  display: flex;
-  width: 100%;
   background-color: #e2e8f0;
+  display: flex;
+  max-width: var(--max-width);
+  margin-left: auto;
+  margin-right: auto;
   flex-direction: column;
 
   @include respond-min(768px) {


### PR DESCRIPTION
Bug fix: standardize page content width alignment with header

The width-limiter class was inconsistently applied across pages, causing some content to align differently than the header. This change ensures all pages maintain consistent width and alignment with the header.

Fixes #266

<img width="1728" alt="Screenshot 2025-06-04 at 8 44 19 PM" src="https://github.com/user-attachments/assets/1e1147c7-4ea3-4ebe-86d5-6150965480e3" />
