### PR TITLE
fix: changes github icon file name displayed on footer

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -50,7 +50,7 @@
           Slack
         </a>
         <a href="https://github.com/valkey-io" target="_blank">
-          <img src="/img/IconGitHub.svg" alt="GitHub Icon" width="20" height="20" />
+          <img src="/img/IconGithub.svg" alt="GitHub Icon" width="20" height="20" />
           GitHub
         </a>
         <a href="https://www.linkedin.com/company/valkey/" target="_blank">


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Fix Github icon not loaded properly on footer
The icon is named `IconGithub.svg` but on the footer element is used as `IconGitHub.svg`

![Captura de Tela 2025-06-05 às 14 06 37](https://github.com/user-attachments/assets/7697b275-5c04-4fd2-9161-e74db03b25cd)

### Issues Resolved

<!-- List any issues this PR will resolve. -->
<!-- Example: closes #1234 -->
Closes #270 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
