### PR TITLE
Adds bloom/search commands to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 public
+build-bloom-command-json
 build-command-docs
 build-command-json
 build-topics

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ public
 build-bloom-command-json
 build-command-docs
 build-command-json
+build-search-command-json
 build-topics
 build-clients
 content/commands/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ public
 build-bloom-command-json
 build-command-docs
 build-command-json
+build-json-command-json
 build-search-command-json
 build-topics
 build-clients


### PR DESCRIPTION
### Description

If building from the instructions in the readme, the generated directory `build-bloom-command-json` and `build-search-command-json` isn't ignored by git. This PR properly adds it to `.gitignore`
 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
