### PR TITLE
Removes banner for 8.1.0 release

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,5 +52,5 @@ publish_hold = [
     "/topics/rdd/"
 ]
 
-banner = "Valkey 8.1 is generally available! [Check it out](https://valkey.io/download/releases/v8-1-0/)"
+banner = ""
 


### PR DESCRIPTION
### Description

Banner points to 8.1.0 release (ancient news). Re-add banner on next major (9.0.0) or minor release (9.1.0). 


 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
