### PR TITLE
Adds deprecation advice

### DIFF
--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -1271,6 +1271,12 @@ pre table {
   border-collapse: collapse;
 }
 
+.replaced-by {
+  display: inline;
+  p {
+    display: inline;
+  }
+}
 .command-group {
   margin-bottom: 2rem;
   

--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -151,7 +151,11 @@
 {% else %}
 <code>ERROR. Command description not loaded</code><br />
 {% endif %}
+{% if command_data_obj.replaced_by %}
+<h3>Deprecation advice</h3>
+Instead of using <code>{{ command_title }}</code> use <div class="replaced-by">{{ command_data_obj.replaced_by | markdown | safe  }}</div>
 
+{% endif %}
 {% set_global resp2_replies = load_data(path="../_data/resp2_replies.json", required=false) -%}
 {% set_global resp3_replies = load_data(path="../_data/resp3_replies.json", required=false) -%}
 {% if resp2_replies and resp3_replies -%}


### PR DESCRIPTION
### Description

On deprecated commands, it adds a "Deprecation Advice" section that nicely tells users what they should use instead of the deprecated command.


 
<img width="799" alt="Screenshot 2025-06-27 at 3 09 03 PM" src="https://github.com/user-attachments/assets/182be6b1-de15-4716-a74c-eb99e1317958" />
<img width="753" alt="Screenshot 2025-06-27 at 3 08 49 PM" src="https://github.com/user-attachments/assets/12dea151-d23a-41dd-950a-36e0faf19920" />
<img width="708" alt="Screenshot 2025-06-27 at 3 08 25 PM" src="https://github.com/user-attachments/assets/129cc8fc-652a-453a-9b34-2b3879e0460a" />

### Issues Resolved

#280 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
