### PR TITLE
Adds a deprecation notice to command list

### DIFF
--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -1289,6 +1289,18 @@ pre table {
 .command-group {
   margin-bottom: 2rem;
   
+  .command-entry .deprecated-notice {
+    text-transform: uppercase;
+    text-decoration: none;
+    color: black;
+    display: inline-block;
+    background-color: #d1d9ff;
+    padding: 0.33rem;
+    border-radius: 3px;
+    font-size: 0.75em;
+    font-weight: 600;
+  }
+
   h2 {
     border-bottom: 1px solid $line;
     padding-bottom: 1rem;

--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -152,7 +152,7 @@
 <code>ERROR. Command description not loaded</code><br />
 {% endif %}
 {% if command_data_obj.replaced_by %}
-<h3>Deprecation advice</h3>
+<h3 id="deprecation-advice">Deprecation advice</h3>
 Instead of using <code>{{ command_title }}</code> use <div class="replaced-by">{{ command_data_obj.replaced_by | markdown | safe  }}</div>
 
 {% endif %}

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -38,11 +38,17 @@
             {% if command_data_obj.container %}
                 {% set command_display = command_data_obj.container ~ " " ~ command_display %}
             {% endif %}
+            {% if command_data_obj.replaced_by %}
+                {% set deprecated = true %}
+            {% else %}
+                {% set deprecated = false %}
+            {% endif %}
             {% set command_entry = [
                 command_display,
                 page.permalink | safe,
                 command_data_obj.summary,
-                command_data_obj.group
+                command_data_obj.group,
+                deprecated
             ] %}
             {% set_global commands_entries = commands_entries | concat(with= [ command_entry ]) %}
         {% endif %}
@@ -58,7 +64,13 @@
             <span>{{ group_descriptions[command_group_description_name].description }}</span>
         </h2>
         {% for entry in command_group | sort(attribute="0") %}
-            <div class="command-entry"><code><a href="{{ entry[1] }}">{{ entry[0] }}</a></code> {{entry[2]}}</div>
+            <div class="command-entry">
+                {% if entry[4] == true %}
+                    <a href="{{ entry[1] }}#deprecation-advice" class="deprecated-notice">deprecated</a>
+                {% endif %}
+                <code><a href="{{ entry[1] }}">{{ entry[0] }}</a></code> {{entry[2]}} 
+                
+            </div>
         {% endfor %}
         <div class="command-group-meta">
             <small><a href="#top">Back to top</a></small>


### PR DESCRIPTION
### Description

While the command pages do have a "deprecation advice" section, the command list doesn't reveal which commands are deprecated. This PR adds a 'pill' link to each deprecated command. Clicking on the link directs the user to the deprecation advice heading on the command page.

<img width="525" height="137" alt="Screenshot 2025-07-16 at 9 01 07 AM" src="https://github.com/user-attachments/assets/f2ce7506-f664-4eda-8e13-7c1323d3a0cd" />

### Issues Resolved

valkey-io/valkey-doc#316


### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
