### PR TITLE
Changes variable names to prevent bizarre client container sidebar issue

### DIFF
--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -238,22 +238,21 @@ Instead of using <code>{{ command_title }}</code> use <div class="replaced-by">{
         {% set command_data = load_data(path= json_path, required= false) %}
         {% if command_data %}
             {% set command_obj_name = commands::command_obj_name(command_data= command_data) %}
-            {% set command_data_obj = command_data[command_obj_name] %}
+            {% set list_command_data_obj = command_data[command_obj_name] %}
             {% set command_display = command_obj_name %}
-            {% if command_data_obj.container %}
-                {% set command_display = command_data_obj.container ~ " " ~ command_display %}
+            {% if list_command_data_obj.container %}
+                {% set command_display = list_command_data_obj.container ~ " " ~ command_display %}
             {% endif %}
             {% set command_entry = [
                 command_display,
                 page.permalink | safe,
-                command_data_obj.summary,
-                command_data_obj.group
+                list_command_data_obj.summary,
+                list_command_data_obj.group
             ] %}
             {% set_global commands_entries = commands_entries | concat(with= [ command_entry ]) %}
         {% endif %}
     {% endfor %}
 {% endfor %}
-{% set_global grouped = commands_entries | sort(attribute="3") | group_by(attribute="3") %}
 
 <div class="sb-search-container">
     <input type="text" id="sidebar-search-box" placeholder="Search within documents" onkeyup="searchSidebarCommands()" />


### PR DESCRIPTION
### Description

It looks like in #299 the sidebar code was copy/pasted from the command section into the command page. Both pages uses the global variable named `command_data_obj`, so when there wasn't a container explicitly from the command entry, it just used the one from the page.

In this PR, I namespaced the variable name to fix the command names in the list. Additionally, I removed an unused global that sorted/grouped all the commands.

I've also noticed that the build times have shot up after #299 to around 50 seconds - which is bonkers. Given the repetitious nature of this page element, this should be abstracted into a macro and/or cached during build. At time of writing there is 416 pages rendered in this section, each one has to open 416 + 4 (json files that index all the commands). That means that generating this sidebar adds 174,720 JSON file opens and parses. I will file a seperate issue to track.

### Issues Resolved

#319

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
