### PR TITLE
generate once, load many

### DIFF
--- a/content/command-list/_index.md
+++ b/content/command-list/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Command List"
+template = "command-list.html"
+page_template = "blog-page.html"
++++

--- a/templates/command-list.html
+++ b/templates/command-list.html
@@ -1,0 +1,35 @@
+{% import "macros/command.html" as commands %}
+
+{% set commands_entries = [] %}
+{% set commands_section = get_section(path="commands/_index.md") %}
+{% for page in commands_section.pages %}
+
+    {% for json_path in [
+        commands::command_json_path(slug=page.slug),
+        commands::command_bloom_json_path(slug=page.slug),
+        commands::command_json_json_path(slug=page.slug),
+        commands::command_search_json_path(slug=page.slug)
+    ] %}
+        {% set command_data = load_data(path= json_path, required= false) %}
+        {% if command_data %}
+            {% set command_obj_name = commands::command_obj_name(command_data= command_data) %}
+            {% set list_command_data_obj = command_data[command_obj_name] %}
+            {% set command_display = command_obj_name %}
+            {% if list_command_data_obj.container %}
+                {% set command_display = list_command_data_obj.container ~ " " ~ command_display %}
+            {% endif %}
+            {% set command_entry = [
+                command_display,
+                page.permalink | safe,
+                list_command_data_obj.summary,
+                list_command_data_obj.group
+            ] %}
+            {% set_global commands_entries = commands_entries | concat(with= [ command_entry ]) %}
+        {% endif %} 
+    {% endfor %}
+{% endfor %}
+
+{% set alpha_entries = commands_entries | sort(attribute="0")  %}
+{% for entry in alpha_entries  %}
+    <li class="command-list-item"><code><a href="{{ entry[1] }}">{{ entry[0] }}</a></code></li>
+{% endfor %}

--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -225,34 +225,6 @@ Instead of using <code>{{ command_title }}</code> use <div class="replaced-by">{
 
 {% block related_content %}
 {# Set up variables for sidebar, similar to commands.html #}
-{% set_global group_descriptions = load_data(path= "../_data/groups.json", required= false) %}
-{% set commands_entries = [] %}
-{% set commands_section = get_section(path="commands/_index.md") %}
-{% for page in commands_section.pages %}
-    {% for json_path in [
-        commands::command_json_path(slug=page.slug),
-        commands::command_bloom_json_path(slug=page.slug),
-        commands::command_json_json_path(slug=page.slug),
-        commands::command_search_json_path(slug=page.slug)
-    ] %}
-        {% set command_data = load_data(path= json_path, required= false) %}
-        {% if command_data %}
-            {% set command_obj_name = commands::command_obj_name(command_data= command_data) %}
-            {% set list_command_data_obj = command_data[command_obj_name] %}
-            {% set command_display = command_obj_name %}
-            {% if list_command_data_obj.container %}
-                {% set command_display = list_command_data_obj.container ~ " " ~ command_display %}
-            {% endif %}
-            {% set command_entry = [
-                command_display,
-                page.permalink | safe,
-                list_command_data_obj.summary,
-                list_command_data_obj.group
-            ] %}
-            {% set_global commands_entries = commands_entries | concat(with= [ command_entry ]) %}
-        {% endif %}
-    {% endfor %}
-{% endfor %}
 
 <div class="sb-search-container">
     <input type="text" id="sidebar-search-box" placeholder="Search within documents" onkeyup="searchSidebarCommands()" />
@@ -266,14 +238,18 @@ Instead of using <code>{{ command_title }}</code> use <div class="replaced-by">{
 </div>
 
 <h2 id="command-list-title">Alphabetical Command List</h2>
-<ul id="command-list">
-{% set alpha_entries = commands_entries | sort(attribute="0")  %}
-{% for entry in alpha_entries  %}
-    <li class="command-list-item"><code><a href="{{ entry[1] }}">{{ entry[0] }}</a></code></li>
-{% endfor %}
-</ul>
-
+<ul id="command-list"></ul>
 <script>
+document.addEventListener("DOMContentLoaded", function() {
+    var 
+        commandListEl = document.getElementById('command-list'),
+        f =  fetch("/command-list/");
+
+    f.then((r) => r.text()).then((v) => { commandListEl.innerHTML = v; })
+    f.catch((error) => { commandListEl.innerHTML = "Could not load command list."; });
+});
+
+
 function searchSidebarCommands() {
     var input = document.getElementById("sidebar-search-box").value.toLowerCase();
     var commandList = document.getElementById("command-list");


### PR DESCRIPTION
### Description

When the side bar was added to the command page it caused a massive increase in build times (see #321). This was caused by each command page needing to pull every command JSON file into to generate the list.

This PR takes a different approach, it adds a page (`/command-list/`), that is generated once, which contains the all the commands formatted as list items. Then, on each command page, it pulls that content in with some simple javascript. 

Full build times were previously taking 40-70 seconds. After this change, the build times are taking approximately 1.2 seconds.

```
Building site...
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 564 pages (0 orphan) and 8 sections
Warning: Highlight language plaintext not found
Done in 1.2s.
```
 
### Issues Resolved

#321

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
