### PR TITLE
remove deprecation notice due to the great un-deprecation

### DIFF
--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -25,7 +25,7 @@
         {% set command_title =  command_obj_name %}
     {% endif %}
     {% set command_title = command_title | upper %}
-    {% if command_data_obj.deprecated_since %}
+    {% if command_data_obj.deprecated_since and (command_title == "SLAVEOF" or command_title == "CLUSTER SLAVES") %}
         {% set deprecated = "Deprecated" %}
     {% endif %}
 {% else %}


### PR DESCRIPTION
### Description

There is a lot of confusion about the meaning of deprecation in Valkey and there is an effort to formally un-deprecate a number of commands (See #[2459](https://github.com/valkey-io/valkey/issues/2459)). As such, this PR removes the "Deprecated" notice for the commands under reconsideration.


### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
