### PR TITLE
removes keyspace since event is over

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,5 +52,3 @@ publish_hold = [
     "/topics/rdd/"
 ]
 
-banner = "Join us in Amsterdam on August 28 for the Valkey User Conference: [Keyspace](/events/keyspace-2025)"
-


### PR DESCRIPTION
### Description

Removes Keyspace event banner.

 
### Issues Resolved

#341

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
