### PR TITLE
Fix command-to-command links

### DIFF
--- a/templates/macros/command.html
+++ b/templates/macros/command.html
@@ -69,7 +69,9 @@
     | regex_replace(pattern=`\]\(\.\./topics/(?P<fname>.*?).md#(?P<hash>.*?)\)`, rep=`](/topics/$fname#$hash)`)
     | regex_replace(pattern=`\]\(\.\./topics/(?P<fname>.*?).md\)`, rep=`](/topics/$fname)`)
     | regex_replace(pattern=`\[(?P<token>.*?)\]:\s+\.\./topics/(?P<fname>.*?).md`, rep=`[$token]: /topics/$fname`)
-    | regex_replace(pattern=`\[(?P<token>.*?)\]:\s+(?P<fname>.*?).md`, rep=`[$token]: $fname`)
+    | regex_replace(pattern=`\]\((?P<fname>[\w\.-]*?)\.md#(?P<hash>.*?)\)`, rep=`](/commands/$fname#$hash)`)
+    | regex_replace(pattern=`\]\((?P<fname>[\w\.-]*?)\.md\)`, rep=`](/commands/$fname)`)
+    | regex_replace(pattern=`\[(?P<token>.*?)\]:\s+(?P<fname>[\w\.-]*?).md`, rep=`[$token]: /commands/$fname`)
     | safe
     }}
 {%- endmacro fix_links -%}


### PR DESCRIPTION
Fix broken links from command pages to other command pages.

Example: The link to DEL on the page https://valkey.io/commands/unlink/

Without this PR, the link points to https://valkey.io/commands/unlink/del.md which doesn't exist.

With this PR, the link points to the correct page https://valkey.io/commands/del/

Fixes #351