### PR TITLE
fixes title metadata that messes with LinkedIn

### DIFF
--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -34,6 +34,17 @@
     Valkey
     {%- endif -%}
     </title>
+    <meta name="title" property="og:title" content="{%- if command_title -%}
+    Valkey Command: {{ command_title }}
+    {%- elif frontmatter_title -%}
+    Valkey Documentation: {{ frontmatter_title }}
+    {%- elif page.title -%}
+    Valkey: {{ page.title }}
+    {%- elif section.title -%}
+    Valkey: {{ section.title }}
+    {%- else -%}
+    Valkey
+    {%- endif -%}">
 
     <link rel="stylesheet" href="/css/styles.css">
     <link rel="alternate" type="application/atom+xml" title="Atom feed" href="{{ get_url(path="atom.xml", trailing_slash=false) }}" />


### PR DESCRIPTION
### Description

On LinkedIn, sharing a post from Valkey.io it always makes the title weirdly "command reference".

Looking into the LinkedIn Debugging tool it seems like it can't infer our title so we need to add an explicit `og:title` metadata tag. This adds the same logic as the title with colon seperating the page type and title (instead of the middot entity, which is not allowed in this format).


### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
