### PR TITLE
Community event landing page 

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -2,7 +2,7 @@
 title = "Community"
 description = "Join the Valkey community"
 template = "community.html"
-
+page_template = "community.html"
 [extra]
 cards = [
   { icon = "icon-question.svg", title = "Ask Questions", description = "If you have any inquiries about Valkey, feel free to join the conversation on our GitHub discussions or chat with us on Slack.", links = [

--- a/templates/community.html
+++ b/templates/community.html
@@ -4,11 +4,23 @@
   
   <div class="community-section">
     <div class="community-header">
+      {% if section %}
+      {{ section.content | markdown | safe }}
+      {% else %}
       {{ page.content | markdown | safe }}
+      {% endif %}
     </div>
-    {% if page.extra.cards %}
+    {% set cards_meta = get_section(path="community/_index.md", metadata_only=true) %}
+    {% if (page and page.extra and page.extra.cards)  %} 
+      {% set page_cards = page.extra.cards %}
+    {% else %}
+      {% set page_cards = [] %}
+    {% endif %}
+    {% set cards = page_cards | concat(with= cards_meta.extra.cards) %}
+    
+    {% if cards %}
       <div class="community-card-grid">
-        {% for card in page.extra.cards %}
+        {% for card in cards%}
           <div class="community-card">
             <img src="/img/{{ card.icon }}" alt="{{ card.title }}" class="community-card-icon" />
             <h3>{{ card.title }}</h3>


### PR DESCRIPTION
### Description

(exactly the same as #364 but based on commit 4888f10... for whatever reason GitHub _did not_ like the combinations of changes - it was far easier to just manually move these changes over top of 4888f10 and do another PR)

This PR refactors the /community/ page into a section. It allows us to add unique landing page variations of the community page.

For example, if you add an markdown file to /content/community/ this will create a new URL under /community/.

This is especially useful for events where we may want to direct attendees to a specific set of resources for that event. For example, I could send PyConAfrica attendees to a vakey.io/community/pycon-africa via a QR code. On this specific landing page it would contain information about demos and/or slides relevant to the event along side our standard items on the community page.
 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
