### PR TITLE
Fix landing page hero bg

### DIFF
--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -1595,7 +1595,7 @@ html.banner-hidden .banner {
   background-size: cover;
   background-position: right center;
   background-color: #30186e;
-  background-image: linear-gradient(to bottom, rgba(48, 24, 110, 0.0), rgba(48, 24, 110, 0.75)), url('/img/hero-bg.webp');
+  background-image: linear-gradient(to bottom, rgba(48, 24, 110, 0.15), rgba(48, 24, 110, 0.75)), url('/img/hero-bg.webp');
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1605,7 +1605,7 @@ html.banner-hidden .banner {
   &::after {
     content: "";
     position: absolute; inset: 0;
-    background-image: linear-gradient(to bottom, rgba(48, 24, 110, 0.15), rgba(48, 24, 110, 100));
+    background-image: linear-gradient(to bottom, rgba(48, 24, 110, 0), rgba(48, 24, 110, 100));
     pointer-events: none;
   }
 


### PR DESCRIPTION
Hey @madolson here is a fix to the "sharp line" in the new hero image changes

<img width="1728" height="1040" alt="Screenshot 2025-10-02 at 8 18 09 AM" src="https://github.com/user-attachments/assets/7d6dd4f9-5b2b-48d2-94c2-41071ade2c16" />
