### PR TITLE
Try Valkey for Workshops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ _data/modules.json
 .vscode/*
 .idea/*
 tmp/*
+static/debug

--- a/content/try-valkey/_index.md
+++ b/content/try-valkey/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Try Valkey"
+template = "valkey-try-me.html"
+[extra]
+state_file = "https://download.valkey.io/try-me-valkey/8.1.0/states/state.bin.gz"
+filesystem_base_url = "https://download.valkey.io/try-me-valkey/8.1.0/fs/alpine-rootfs-flat"
+filesystem_base_fs = "https://download.valkey.io/try-me-valkey/8.1.0/fs/alpine-fs.json"
++++
+

--- a/content/try-valkey/index.md
+++ b/content/try-valkey/index.md
@@ -1,5 +1,0 @@
-+++
-title = "Try Valkey"
-template = "valkey-try-me.html"
-+++
-

--- a/content/try-valkey/pyconafrica-workshop.md
+++ b/content/try-valkey/pyconafrica-workshop.md
@@ -1,11 +1,11 @@
 +++
-title = "Try Valkey"
+title = "Try Valkey for PyCon Africa 2025"
 template = "valkey-try-me.html"
 [extra]
-state_file = "/debug//pyconafrica/states/tmux-cli-activated.bin.gz"
-filesystem_base_url = "/debug/pyconafrica/fs/alpine-rootfs-flat"
-filesystem_base_fs = "/debug/pyconafrica/fs/alpine-fs.json"
+state_file = "https://download.valkey.io/try-me-valkey/pyconafrica/states/state.bin.gz"
+filesystem_base_url = "https://download.valkey.io/try-me-valkey/pyconafrica/fs/alpine-rootfs-flat"
+filesystem_base_fs = "https://download.valkey.io/try-me-valkey/pyconafrica/fs/alpine-fs.json"
 +++
 
 
-Howdy!
+This is an in-browser Valkey server, `valkey-cli`, and Python,that runs directly within your browser using a [V86](https://github.com/copy/v86) emulator, requiring no external installations. You will use this to complete  the workshop.

--- a/content/try-valkey/pyconafrica-workshop.md
+++ b/content/try-valkey/pyconafrica-workshop.md
@@ -1,0 +1,11 @@
++++
+title = "Try Valkey"
+template = "valkey-try-me.html"
+[extra]
+state_file = "/debug//pyconafrica/states/tmux-cli-activated.bin.gz"
+filesystem_base_url = "/debug/pyconafrica/fs/alpine-rootfs-flat"
+filesystem_base_fs = "/debug/pyconafrica/fs/alpine-fs.json"
++++
+
+
+Howdy!

--- a/templates/valkey-try-me.html
+++ b/templates/valkey-try-me.html
@@ -11,9 +11,13 @@
     <link rel="stylesheet" href="https://download.valkey.io/try-me-valkey/vos/valkey-try-me.css" />
     
     <!-- Body -->
+    {% if page %}
+    {{ page.content | markdown | safe }}
+    {% else %}
     <title>Try Valkey</title>
     <p>This is an in-browser Valkey server and CLI that runs directly within your browser using a <a href="https://github.com/copy/v86">V86</a> emulator, requiring no external installations. </p>
     <p>Try it out below:</p>
+    {% endif %}
     <div id="terminalWrapper" class="container" style="display: none;">
         <div id="terminal-container"></div>
     </div>
@@ -30,7 +34,11 @@
 
     <script>
         "use strict";
-        const FILE_URL = "https://download.valkey.io/try-me-valkey/8.1.0/states/state.bin.gz";  // Path to the .gz file
+        {% if page %}
+        const FILE_URL = "{{ page.extra.state_file | safe }}";  // Path to the .gz file
+        {% else %}
+        const FILE_URL = "{{ section.extra.state_file | safe }}";  // Path to the .gz file
+        {% endif %}
         const CACHE_KEY = "valkey_binary_cache";
         const LAST_MODIFIED_KEY = "valkey_last_modified";
         let emulator;
@@ -138,8 +146,13 @@
                 memory_size: 512 * 1024 * 1024,
                 bios: { url: "https://download.valkey.io/try-me-valkey/vos/v86/bios/seabios.bin" },
                 filesystem: {
-                    baseurl: "https://download.valkey.io/try-me-valkey/8.1.0/fs/alpine-rootfs-flat",
-                    basefs: "https://download.valkey.io/try-me-valkey/8.1.0/fs/alpine-fs.json",
+                    {% if page %}
+                    baseurl: "{{ page.extra.filesystem_base_url | safe }}",
+                    basefs: "{{ page.extra.filesystem_base_fs | safe }}",
+                    {% else %}
+                    baseurl: "{{ section.extra.filesystem_base_url | safe }}",
+                    basefs: "{{ section.extra.filesystem_base_fs | safe }}",
+                    {% endif %}
                 },
                 autostart: true,
                 bzimage_initrd_from_filesystem: true,


### PR DESCRIPTION
### Description

This PR accomplishes two things:
1. Generalized the try-valkey interface allowing for multiple, isolated instances of try-valkey to co-exist on valkey.io
2. Adds a new instance of try-valkey for the PyCon Africa conference workshop.
 
Note: the actual distribution needs to be uploaded to the download.valkey.io CDN for the workshop to be functional.

### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
