### PR TITLE
feat: add go module redirect for k8s-operator

### DIFF
--- a/content/valkey-operator/_index.md
+++ b/content/valkey-operator/_index.md
@@ -1,0 +1,4 @@
++++
+template = "operator.html"
+title = "Valkey-Operator"
++++

--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -9,6 +9,8 @@
     <meta property="og:image" content="/img/valkey-logo-og.png" />
     {% if page and page.description %}<meta name="description" content="{{ page.description}}" />
     {% elif section and section.description %}<meta name="description" content="{{ section.description}}" />{% endif %}
+    {% if section.title and section.title == "Valkey-Operator" %}<meta name="go-import" content="valkey.io/valkey-operator git https://github.com/valkey-io/valkey-operator">
+    <meta name="go-source" content="valkey.io/valkey-operator https://github.com/valkey-io/valkey-operator  https://github.com/valkey-io/valkey-operator/tree/main{/dir} https://github.com/valkey-io/valkey-operator/blob/main{/dir}/{file}#L{line}">{% endif %}
 
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/img/favicon/apple-touch-icon.png">

--- a/templates/operator.html
+++ b/templates/operator.html
@@ -1,0 +1,5 @@
+{% extends "fullwidth.html" %}
+{% import "macros/docs.html" as docs %}
+
+{% block main_content %}
+{% endblock main_content %}


### PR DESCRIPTION
### Description

the Golang import path for the new valkey-operator is valkey.io/valkey-operator this patch wires up a redirect to use the patch  but also keep the code within GitHub.
 
### Issues Resolved

<!-- List any issues this PR will resolve. -->
<!-- Example: closes #1234 -->

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
