### PR TITLE
fixes file name in font matter for workshop try valkey

### DIFF
--- a/content/try-valkey/pyconafrica-workshop.md
+++ b/content/try-valkey/pyconafrica-workshop.md
@@ -2,7 +2,7 @@
 title = "Try Valkey for PyCon Africa 2025"
 template = "valkey-try-me.html"
 [extra]
-state_file = "https://download.valkey.io/try-me-valkey/pyconafrica/states/state.bin.gz"
+state_file = "https://download.valkey.io/try-me-valkey/pyconafrica/states/tmux-cli-activated.bin.gz"
 filesystem_base_url = "https://download.valkey.io/try-me-valkey/pyconafrica/fs/alpine-rootfs-flat"
 filesystem_base_fs = "https://download.valkey.io/try-me-valkey/pyconafrica/fs/alpine-fs.json"
 +++


### PR DESCRIPTION
### Description

#378 had an incorrect state filename which cause the workshop to hang during load. This PR fixes the issue.
 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
