### PR TITLE
adds custom meta to head via front matter

### DIFF
--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -7,6 +7,13 @@
     <meta name="Copyright" content="" />
     <meta name="keywords" content="open-source, valkey" />
     <meta property="og:image" content="/img/valkey-logo-og.png" />
+    {% if page and page.extra and page.extra.custom_meta%}
+    {{ page.extra.custom_meta | safe }}
+    {% endif %}
+    {% if section and section.extra and section.extra.custom_meta%}
+    {{ section.extra.custom_meta | safe }}
+    {% endif %}
+
     {% if page and page.description %}<meta name="description" content="{{ page.description}}" />
     {% elif section and section.description %}<meta name="description" content="{{ section.description}}" />{% endif %}
 


### PR DESCRIPTION
### Description

In #380, @dmolik was trying to add a custom meta tags for the go package manager. His solution was limited and specific to to the specific situation with the go package manager but custom tags in the header are not an uncommon ask, so I wanted a generalizable solution. This PR adds the ability for add tags directly to any page in the meta block.

 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
