### PR TITLE
updated try-valkey Valkey 9.0.0

### DIFF
--- a/content/try-valkey/_index.md
+++ b/content/try-valkey/_index.md
@@ -2,8 +2,8 @@
 title = "Try Valkey"
 template = "valkey-try-me.html"
 [extra]
-state_file = "https://download.valkey.io/try-me-valkey/8.1.0/states/state.bin.gz"
-filesystem_base_url = "https://download.valkey.io/try-me-valkey/8.1.0/fs/alpine-rootfs-flat"
-filesystem_base_fs = "https://download.valkey.io/try-me-valkey/8.1.0/fs/alpine-fs.json"
+state_file = "https://download.valkey.io/try-me-valkey/9.0.0/states/state.bin.gz"
+filesystem_base_url = "https://download.valkey.io/try-me-valkey/9.0.0/fs/alpine-rootfs-flat"
+filesystem_base_fs = "https://download.valkey.io/try-me-valkey/9.0.0/fs/alpine-fs.json"
 +++
 


### PR DESCRIPTION
Signed-off-by: Shai Zarka <zarkash@amazon.com>

### Description

updates the try valkey page to point to valkey 9.0.0
see below:
<img width="949" height="698" alt="Screenshot 2025-10-22 at 20 34 42" src="https://github.com/user-attachments/assets/0f50f2cc-c788-42ab-9486-9964a08a2175" />

 
### Issues Resolved

<!-- List any issues this PR will resolve. -->
<!-- Example: closes #1234 -->

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
