### PR TITLE
adds link to event registration and modifies template for footer

### DIFF
--- a/content/events/keyspace-beijing-2025/index.md
+++ b/content/events/keyspace-beijing-2025/index.md
@@ -5,6 +5,7 @@ date= 2025-08-28 01:01:01
 [extra]
 body_class = "keyspace-2025"
 event_logo = "/events/keyspace-beijing-2025/keyspace-logo-beijing.png"
+footer_add = "Header image: [The Horsehead Nebula and its surroundings. The reflection nebula NGC 2023 in the bottom left corner.](https://en.wikipedia.org/wiki/Horsehead_Nebula#/media/File:Horsehead_and_flame_Nebulea_384mm_scope_Ha-RGB.jpg) License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)"
 +++
 
 Keyspace 北京峰会是开发者、SRE 和 DevOps 专家齐聚一堂，分享 Valkey 的技术、最佳实践和新用途的盛会。您将在为期一天的活动中与项目维护人员、社区爱好者和思想领袖见面交流。
@@ -26,6 +27,6 @@ Dongsheng Building, Tower A, No. 8 Zhongguancun East Road, Haidian District, Bei
 
 ## 门票 / Registration
 
-即将推出
+[领取您的免费门票](https://www.wjx.top/vm/tqTMGH4.aspx)
 
-Coming soon.
+[Get your free ticket](https://www.wjx.top/vm/tqTMGH4.aspx)

--- a/templates/default.html
+++ b/templates/default.html
@@ -116,6 +116,9 @@
       <p>
         Logo design by <a href="https://github.com/dizys" target="_blank">Ziyang.</a>
       </p>
+    {%- if page and page.extra and page.extra.footer_add -%}
+      {{ page.extra.footer_add | markdown | safe  }}
+    {%- endif -%}
     </div>
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=4682283c-f8b7-410c-9c31-c6d7944cee8b" />
   </div>


### PR DESCRIPTION
### Description

1. Adds the link to the event registration (in two langauges)
2. Modifies the template to allow for footer injection. In this case, we need to put the credit for the image in the header, but it can be generally useful for anything we don't want to end up on the page itself.
 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
