### PR TITLE
Support website links in client list and fix template variable shadowing

### DIFF
--- a/templates/client-list.html
+++ b/templates/client-list.html
@@ -37,6 +37,9 @@
                             <h3 id="{{ client.name | slugify }}">{{ client.name }}</h3>
                             <ul>
                                 <li><strong>Repo:</strong> <a href="{{ client.repo }}">{{ client.name }}</a></li>
+                                {% if client.website %}
+                                    <li><strong>Website:</strong> <a href="{{ client.website }}">{{ client.website }}</a></li>
+                                {% endif %} 
                                 <li>
                                     <strong>Installation:</strong>
                                     {% if client.installation is iterable %}


### PR DESCRIPTION
## Overview
This PR is a proposal to add a website link to the client list page to support linking the new Valkey GLIDE website. 

It also fixes a bug in the template file.

## Issue
The client page only display repo links and does not support website link.

### Adding Website Links

The template now displays a link to the client's website, if one is provided in the client's data file. This is handled by conditionally rendering the link only when a non-empty website URL is available.

Here's what the python section looks like:
<img width="1389" height="611" alt="image" src="https://github.com/user-attachments/assets/12a4ada6-eb60-4254-9002-c1291090abdf" />

### Fixes Variable Shadowing

Resolves an issue where a `client` variable was being shadowed within a loop, which could lead to unpredictable behavior. The shadowing variable has been renamed to `first_client`.

### Related issues
https://github.com/valkey-io/valkey-io.github.io/issues/416
