### PR TITLE
Delete logic related to implicit ACL categories

### DIFF
--- a/templates/command-page.html
+++ b/templates/command-page.html
@@ -102,53 +102,11 @@
         <dd>{{ command_data_obj.since }}</dd>
     <dl>
     {% endif %}
-    {% if command_data_obj.acl_categories or command_data_obj.command_flags %}
+    {% if command_data_obj.acl_categories %}
     <dl>
         <dt>ACL Categories:</dt>
         <dd>
-            {% set all_categories = [] %}
-            
-            {% if command_data_obj.acl_categories %}
-                {% set all_categories = command_data_obj.acl_categories %}
-            {% endif %}
-            
-            {% if command_data_obj.command_flags %}
-                {# Command flag WRITE implies ACL category WRITE #}
-                {% if "WRITE" in command_data_obj.command_flags %}
-                    {% set all_categories = all_categories | concat(with="WRITE") %}
-                {% endif %}
-
-                {# Command flag READONLY and not ACL category SCRIPTING implies ACL category READ #}
-                {% if "READONLY" in command_data_obj.command_flags and (not command_data_obj.acl_categories or not "SCRIPTING" in command_data_obj.acl_categories) %}
-                    {% set all_categories = all_categories | concat(with="READ") %}
-                {% endif %}
-
-                {# Command flag ADMIN implies ACL categories ADMIN and DANGEROUS #}
-                {% if "ADMIN" in command_data_obj.command_flags %}
-                    {% set all_categories = all_categories | concat(with="ADMIN") | concat(with="DANGEROUS") %}
-                {% endif %}
-
-                {% if "FAST" in command_data_obj.command_flags %}
-                    {% set all_categories = all_categories | concat(with="FAST") %}
-                {% endif %}
-
-                {# Command flag PUBSUB implies ACL category PUBSUB #}
-                {% if "PUBSUB" in command_data_obj.command_flags %}
-                    {% set all_categories = all_categories | concat(with="PUBSUB") %}
-                {% endif %}
-
-                {# Command flag BLOCKING implies ACL category BLOCKING #}
-                {% if "BLOCKING" in command_data_obj.command_flags %}
-                    {% set all_categories = all_categories | concat(with="BLOCKING") %}
-                {% endif %}
-            {% endif %}
-
-            {# Not ACL category FAST implies ACL category SLOW. "If it's not fast, it's slow." #}
-            {% if "FAST" not in all_categories %}
-                {% set all_categories = all_categories | concat(with="SLOW") %}
-            {% endif %}
-
-            {% for category in all_categories %}
+            {% for category in command_data_obj.acl_categories %}
                 @{{ category|lower }}{% if not loop.last %}, {% endif %}
             {% endfor %}
         </dd>


### PR DESCRIPTION
### Description

As of https://github.com/valkey-io/valkey/pull/2887 all ACL categories are explicit and we don't need to assume anything about them.
 
### Current behaviour (All ACL categories that were implicit are duplicated):
<img width="1039" height="822" alt="Screenshot 2025-12-03 at 15 37 50" src="https://github.com/user-attachments/assets/088e5113-d1ef-4bd8-93b2-4e25da3c45c8" />

### New behaviour (No duplicates):
<img width="1066" height="808" alt="Screenshot 2025-12-03 at 15 37 35" src="https://github.com/user-attachments/assets/9f2fa00d-c0fd-4975-988e-011dcdbaad3c" />


### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
