### PR TITLE
9.0 Blog: Update links to point to 9.0.1

### DIFF
--- a/content/blog/2025-10-21-introducing-valkey-9/index.md
+++ b/content/blog/2025-10-21-introducing-valkey-9/index.md
@@ -83,5 +83,5 @@ And, perhaps, most importantly, a new, whimsical [LOLWUT](/commands/lolwut/) gen
 ## Get it today
 
 Valkey 9.0 was built by the collaborative efforts of dozens of contributors.
-Make sure and grab Valkey 9.0 today as a [binary, container](/download/releases/v9-0-0), or [build it from source](https://github.com/valkey-io/valkey/releases/tag/9.0.0) and watch for it in your favourite Linux distribution.
+Make sure and grab Valkey 9.0 today as a [binary, container](/download/releases/v9-0-1), or [build it from source](https://github.com/valkey-io/valkey/releases/tag/9.0.1) and watch for it in your favourite Linux distribution.
 Feel free to post a question on our GitHub discussions or Slack and if you find a bug, make sure and tell the team as an issue.


### PR DESCRIPTION
### Description

The 9.0 blog post links to the specific release of 9.0.0 but when 9.0.1 is released, it should point to the most recent patch

See: #428 for long term solution
 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
