### PR TITLE
moves to new syntax highlighter to work with Zola 0.22+

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,8 +7,8 @@ build_search_index = true
 
 generate_feeds = true
 
-[markdown]
-highlight_code = true
+[markdown.highlighting]
+theme = "github-dark-default"
 
 # Needed to stop certain command topics from being destroyed by the slugifier
 [slugify]

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -15,3 +15,18 @@
   font-variant-ligatures: no-common-ligatures;  // disables the common ligatures only
   text-rendering: optimizeSpeed;  // for Safari 7.x
 }
+
+.giallo-l {
+    display: inline-block;
+    min-height: 1lh;
+    width: 100%;
+}
+.giallo-ln {
+    display: inline-block;
+    user-select: none;
+    margin-right: 0.4em;
+    padding: 0.4em;
+    min-width: 3ch;
+    text-align: right;
+    opacity: 0.8;
+}


### PR DESCRIPTION
### Description

Zola 0.22 drops the old syntax highlighter and our current `config.toml` causes a breaking change for those using Zola 0.22 (current).

This movies `config.toml` to the new syntax highlight system. The chosen theme (`github-dark-default`) is very close  and rendered differences are minimal from my checks.

I have tested this on Zola 0.21.0 and 0.22.1 and both seem to work.

### Issues Resolved
n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
