### PR TITLE
Releases pages link and (optionally) forward to latest versions

### DIFF
--- a/templates/download.html
+++ b/templates/download.html
@@ -1,4 +1,5 @@
 {% extends "right-aside.html" %}
+{% import "macros/release.html" as release_macros %}
 
 {% block subhead_content%}
 <h1 class="page-title">Download Latest</h1>
@@ -31,7 +32,7 @@ The <a href="./releases/">releases</a> page contains links to download all curre
 
 
 <h3> Version {{major}}.x.x </h3>
-{% include "includes/release.html" %}
+{{ release_macros::release_info(date= most_recent_release_page[0].date, release= most_recent_release_page[0].extra ) }}
 
 <h2> Latest supported version of past releases</h2>
 
@@ -42,7 +43,7 @@ The <a href="./releases/">releases</a> page contains links to download all curre
         {% set_global major = older_major %}
         {% set release = older_release.extra %}
         <h3> Version {{major}}.x.x </h3>
-        {% include "includes/release.html" %}
+        {{ release_macros::release_info(date= older_release.date, release= older_release.extra ) }}
     {% endif %}
 {% endfor %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,5 @@
 {%- extends "default.html" -%}
+{% import "macros/release.html" as release_macros %}
 
 {%- block content -%}
 {% if section.extra and section.extra.hero %}
@@ -29,15 +30,13 @@
                 {% endfor %}
                 
                 {% set most_recent_release_page = active_releases | slice(end= 1) %}
-                {% set release_date = most_recent_release_page[0].date %}
-                {% set release = most_recent_release_page[0].extra %}
                 
-                {% set split_ver = release.tag | split(pat=".")%}
+                {% set split_ver = most_recent_release_page[0].extra.tag | split(pat=".")%}
                 {% set_global major = split_ver | nth(n= 0) %}
                 
                 <h3> Version {{major}}.x.x </h3>
                 <div class="inner-card">
-                    {% include "includes/release.html" %}
+                    {{ release_macros::release_info(date= most_recent_release_page[0].date, release= most_recent_release_page[0].extra ) }}
                 </div>
 
                 <h3> Latest supported version of past releases</h3>
@@ -48,9 +47,8 @@
                         {% set older_major = older_split_ver | nth(n= 0) %}
                         {% if older_major != major %}
                             {% set_global major = older_major %}
-                            {% set release = older_release.extra %}
                             <h4> Version {{major}}.x.x </h4>
-                            {% include "includes/release.html" %}
+                            {{ release_macros::release_info(date= older_release.date, release= older_release.extra ) }}
                         {% endif %}
                     {% endfor %}
                 </div>                   

--- a/templates/macros/release.html
+++ b/templates/macros/release.html
@@ -1,4 +1,5 @@
-<strong>Release Date:</strong>  {{ release_date | date(format="%Y-%m-%d") }} <br/> 
+{% macro release_info(date, release) %}
+<strong>Release Date:</strong>  {{ date| date(format="%Y-%m-%d") }} <br/> 
 <strong>GitHub Release:</strong> <a href="https://github.com/valkey-io/valkey/releases/tag/{{release.tag}}">{{release.tag}}</a><br />
 <hr />
 
@@ -39,3 +40,6 @@
     {% endfor %}
 {% endfor  %}
 {% endif %}
+
+{% endmacro release_info %}
+

--- a/templates/release-page.html
+++ b/templates/release-page.html
@@ -1,71 +1,103 @@
 {% extends "right-aside.html" %}
+{% import "macros/release.html" as release_macros %}
 
 {% block subhead_content%}
 <h1 class="page-title">Download Valkey {{page.title}}</h1>
 {% endblock subhead_content%}
+
 {% block main_content %}
-{% set release = page.extra %}
-{% set page_ver_parts = release.tag | split(pat=".") %}
+{% set page_ver_parts = page.extra.tag | split(pat=".") %}
 {% set page_major = page_ver_parts.0 %}
+{% set page_major_number = page_major | int %}
 {% set page_minor = page_ver_parts.1 %}
 {% set page_patch = page_ver_parts.2 %}
-{% set release_date = page.date %}
 {% set this_minor_line = [] %}
 {% set this_major_line = [] %}
 {% set section_file = page.ancestors.1 %}
 {% set section = get_section(path= section_file) %}
-{% for page in section.pages %}
+{% set sorted_section_pages = section.pages | sort(attribute="extra.tag") %}
+{% set highest_major_version = 0 %}
+
+{% for page in sorted_section_pages %}
     {% set this_version_parts = page.extra.tag | split(pat=".") %}
     {% set this_version_major = this_version_parts.0 %}
+    {% set this_version_major_num = this_version_parts.0 | int %}
     {% set this_version_minor = this_version_parts.1 %}
     {% set this_version_patch = this_version_parts.2 %}
+    {% set this_version_rc = this_version_patch | split(pat="-") | length %}
 
+    {% set ver = [ page.date, page.extra.tag, this_version_major, this_version_minor, this_version_patch, page.slug]  %}
     {% if (page_major == this_version_major) and (page_minor == this_version_minor) %}
-        {% set ver = [ page.date, page.extra.tag, this_version_major, this_version_minor, this_version_patch, page.slug]  %}
         {% set_global this_minor_line  = this_minor_line | concat(with= [ ver ] ) %}
     {% endif %}
     {% if (page_major == this_version_major) %}
-        {% set ver = [ page.date, page.extra.tag, this_version_major, this_version_minor, this_version_patch, page.slug]  %}
         {% set_global this_major_line  = this_major_line | concat(with= [ ver ] ) %}
     {% endif %}
+    {% if (highest_major_version <= this_version_major_num) and (this_version_rc == 1) %}
+        {% set_global highest_major_version = this_version_major_num %}
+        {% set_global latest_major  = ver  %}
+    {% endif %}    
 {% endfor %}
 
 {% set latest_patch = this_minor_line | sort(attribute="0") | last %}
 {% set latest_minor = this_major_line | sort(attribute="0") | last %}
 
 {% set new_patch = (latest_patch.3 == page_minor) and (latest_patch.4 != page_patch) %}
-{% set new_minor = (latest_patch.2 == page_major) and (latest_patch.3 != page_minord) %}
-patch:
-<pre>
-    {{ latest_patch | json_encode(pretty= true) | safe }}
-</pre>
-minor:
-<pre>
-    {{ latest_minor | json_encode(pretty= true) | safe }}
-</pre>
+{% set new_minor = (latest_minor.2 == page_major) and (latest_minor.3 != page_minor) %}
+{% set new_major = page_major_number != highest_major_version %}
 
-
+{% if new_patch or new_minor or new_major %}
+<h2>Available updates for {{page.extra.tag}} </h2>
+<ul>
 {% if new_patch %}
-    There is a new patch version {{latest_patch.2}}.{{latest_patch.3}}.{{latest_patch.4}}
+    {% set_global latest_patch_url = "/download/releases/" ~ latest_patch.5 ~ "/" %}
+    <li>There is a <strong>patch</strong> update: <a href="{{ latest_patch_url | safe }}">{{latest_patch.2}}.{{latest_patch.3}}.{{latest_patch.4}}</a>.</li>
 {% endif %}
 {% if new_minor %}
-    new minor!
+    {% set_global latest_minor_url = "/download/releases/" ~ latest_minor.5 ~ "/"%}
+    <li>There is a <strong>minor</strong> update: <a href="{{ latest_minor_url | safe }}">{{latest_minor.2}}.{{latest_minor.3}}.{{latest_minor.4}}</a>.</li>
 {% endif %}
+{% if new_major %}
+    {% set_global latest_major_url = "/download/releases/" ~ latest_major.5 ~ "/" %}
+    <li>The latest <strong>major</strong> version: <a href="{{ latest_major_url | safe }}">{{latest_major.2}}.{{latest_major.3}}.{{latest_major.4}}</a>.</li>
+{% endif %}
+</ul>
+<hr />
+{%endif%}
 
 
+{{ release_macros::release_info(date= page.date, release= page.extra ) }}
+{# 
 
-{% include "includes/release.html" %}
+The `script` tag below facilitates a forward based on a URL hashtag. For example, as of writing:
 
+- `/download/releases/v8-0-0/#latest-patch` autoforwards to `/download/releases/v8-0-6/`
+- `/download/releases/v8-0-0/#latest-minor` autoforwards to `/download/releases/v8-1-5/`
+- `/download/releases/v8-0-0/#latest-major` autoforwards to `/download/releases/v9-0-1/`
+
+If there isn't a new patch/minor/major then it just becomes a noop when you add the respective hash to the URL
+
+#}
 <script>
 const latest = () => {
-
+    const lower_hash = window.location.hash.toLowerCase(window.location.hash);
+    {% if new_patch %}
+    if (lower_hash == '#latest_patch') {
+        window.location.href = '{{ latest_patch_url | safe }}';
+    }
+    {% endif %}
+    {% if new_minor %}
+    if (lower_hash == '#latest_minor') {
+        window.location.href = '{{ latest_minor_url | safe }}';
+    }
+    {% endif %}
+    {% if new_major %}
+    if (lower_hash == '#latest_major') {
+        window.location.href = '{{ latest_major_url | safe }}';
+    }
+    {% endif %}
 }
-
-document.addEventListener("DOMContentLoaded", () => {
-  console.log("page load");
-});
-window.addEventListener("hashchange", () => {
-  console.log("The hash has changed!");
-});
+document.addEventListener("DOMContentLoaded", latest);
+window.addEventListener("hashchange", latest);
 </script>
 {% endblock main_content %}

--- a/templates/release-page.html
+++ b/templates/release-page.html
@@ -5,7 +5,67 @@
 {% endblock subhead_content%}
 {% block main_content %}
 {% set release = page.extra %}
+{% set page_ver_parts = release.tag | split(pat=".") %}
+{% set page_major = page_ver_parts.0 %}
+{% set page_minor = page_ver_parts.1 %}
+{% set page_patch = page_ver_parts.2 %}
 {% set release_date = page.date %}
+{% set this_minor_line = [] %}
+{% set this_major_line = [] %}
+{% set section_file = page.ancestors.1 %}
+{% set section = get_section(path= section_file) %}
+{% for page in section.pages %}
+    {% set this_version_parts = page.extra.tag | split(pat=".") %}
+    {% set this_version_major = this_version_parts.0 %}
+    {% set this_version_minor = this_version_parts.1 %}
+    {% set this_version_patch = this_version_parts.2 %}
+
+    {% if (page_major == this_version_major) and (page_minor == this_version_minor) %}
+        {% set ver = [ page.date, page.extra.tag, this_version_major, this_version_minor, this_version_patch, page.slug]  %}
+        {% set_global this_minor_line  = this_minor_line | concat(with= [ ver ] ) %}
+    {% endif %}
+    {% if (page_major == this_version_major) %}
+        {% set ver = [ page.date, page.extra.tag, this_version_major, this_version_minor, this_version_patch, page.slug]  %}
+        {% set_global this_major_line  = this_major_line | concat(with= [ ver ] ) %}
+    {% endif %}
+{% endfor %}
+
+{% set latest_patch = this_minor_line | sort(attribute="0") | last %}
+{% set latest_minor = this_major_line | sort(attribute="0") | last %}
+
+{% set new_patch = (latest_patch.3 == page_minor) and (latest_patch.4 != page_patch) %}
+{% set new_minor = (latest_patch.2 == page_major) and (latest_patch.3 != page_minor) %}
+patch:
+<pre>
+    {{ latest_patch | json_encode(pretty= true) | safe }}
+</pre>
+minor:
+<pre>
+    {{ latest_minor | json_encode(pretty= true) | safe }}
+</pre>
+
+
+{% if new_patch %}
+    There is a new patch version {{latest_patch.2}}.{{latest_patch.3}}.{{latest_patch.4}}
+{% endif %}
+{% if new_minor %}
+    new minor!
+{% endif %}
+
+
 
 {% include "includes/release.html" %}
+
+<script>
+const latest = () => {
+
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  console.log("page load");
+});
+window.addEventListener("hashchange", () => {
+  console.log("The hash has changed!");
+});
+</script>
 {% endblock main_content %}

--- a/templates/release-page.html
+++ b/templates/release-page.html
@@ -34,7 +34,7 @@
 {% set latest_minor = this_major_line | sort(attribute="0") | last %}
 
 {% set new_patch = (latest_patch.3 == page_minor) and (latest_patch.4 != page_patch) %}
-{% set new_minor = (latest_patch.2 == page_major) and (latest_patch.3 != page_minor) %}
+{% set new_minor = (latest_patch.2 == page_major) and (latest_patch.3 != page_minord) %}
 patch:
 <pre>
     {{ latest_patch | json_encode(pretty= true) | safe }}

--- a/templates/release-section.html
+++ b/templates/release-section.html
@@ -21,7 +21,7 @@
 
 {% set release_lines_unique = release_lines | unique %}
 {% for line in release_lines_unique %}
-   
+    <h2>{{ line }}.x</h2>
     <ul>
     {% for release in section.pages | sort(attribute="date") | reverse %}
         {% set split_ver = release.extra.tag | split(pat=".")%}

--- a/templates/release-section.html
+++ b/templates/release-section.html
@@ -21,9 +21,9 @@
 
 {% set release_lines_unique = release_lines | unique %}
 {% for line in release_lines_unique %}
-    <h2>{{ line }}.x</h2>
+   
     <ul>
-    {% for release in section.pages | reverse %}
+    {% for release in section.pages | sort(attribute="date") | reverse %}
         {% set split_ver = release.extra.tag | split(pat=".")%}
         {% set major = split_ver | nth(n= 0) %}
         {% set minor = split_ver | nth(n= 1) %}


### PR DESCRIPTION
### Description

Release pages provide a stable URL to point to a version of the software. For example, `/download/releases/v7-2-5/` will always have things like the GitHub tag, release date, and artifact links.

In the past, there has been situations where we've made a major release, found a bug, and did a fast-followed with a patch release to fix it. However, the blog post for that release still points to the release page for the original release, obscuring a bug fix. This has two issues:

1. Release pages don't hint at a newer release being available.
2. There isn't a way to link to a newer release in the same line (patch/minor) (e.g. #428) or to the latest major release

This PR adds a few things around this problem:

#### Release pages have an `Available updates` section.

On each release page, there is section that advises about updates/upgrades, linking to the release pages for each.

<img width="503" height="179" alt="Screenshot 2026-01-29 at 7 50 46 AM" src="https://github.com/user-attachments/assets/72f49ed7-d1aa-4ded-a51e-8b6069d2fa79" />

The script only shows the relevant updates for each version. As an example, 7.2.11 doesn't show 8.x releases, only the latest major:

<img width="347" height="118" alt="Screenshot 2026-01-29 at 7 53 46 AM" src="https://github.com/user-attachments/assets/1c8961c1-44dc-4577-8444-54eaf61f2f09" />


On pages which don't have any updates, the section isn't present.

#### URL hash and forwards

To directly fix #428, this PR adds an optional hash tag to the URL. If you add `#latest_patch`, `#latest_minor` or `#latest_major` to any release page (e.g.  `/download/releases/v7-2-5/`) it will do a javascript forward to the respective latest version. For example:
- `/download/releases/v7-2-5/#latest_patch` ->  `/download/releases/v7-2-11/`
- `/download/releases/v8-0-0/#latest_minor` -> `/download/releases/v8-1-5/`
- `/download/releases/v8-1-5/#latest_major` -> `/download/releases/v9-0-1/`
 
If there isn't new latest for the different hash tags, it's a noop: `/download/releases/v9-0-1/#latest_patch` does nothing. So, for release blogs, we can safely use URLs like `download/releases/v9-0-0/#latest_patch` and users will automatically get the latest patch version. No more obscured releases!

Release candidates are excluded from this logic. 

#### Bug fixes

In writing this feature, I noticed a bug where the multiple releases fragments on the same page (such as on the homepage or `/downloads/`) misreported the release date for all releases as the first listed. 🤦‍♂️  This is a subtle bug because this _often_ but not always the case. 

I additionally tested what 10.0.0 would look like and discovered that, in some context 10.0.0 appeared in the wrong order. Now it's explicitly uses date sorting - the most recent & version numbers are used and 10.0.0 will come out on top.


#### Refactoring

I moved the release fragment from being a zola include to being a macro. This isolates the scope better to prevent the release date bug as above and actually makes the code a little cleaner. 


### Issues Resolved

#428 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
