### PR TITLE
Forward encryption to tls

### DIFF
--- a/build/custom-frontmatter/topics/tls.toml
+++ b/build/custom-frontmatter/topics/tls.toml
@@ -1,0 +1,4 @@
+# Custom front matter
+aliases = [
+    "/topics/encryption/"
+]


### PR DESCRIPTION
### Description

Renamed doc file `topics/encryption.md -> topics/tls.md`, need to forward the old URL to new one.
Can wait until https://github.com/valkey-io/valkey-doc/pull/402 is merged.
 
### Issues Resolved

N/A

### Check List
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
