### PR TITLE
Community events | KCD Beijing 2026 | Valkey on Kubernetes

### DIFF
--- a/content/community/kcd-beijing-2026.md
+++ b/content/community/kcd-beijing-2026.md
@@ -1,0 +1,16 @@
++++
+title = "Welcome KCD Beijing 2026"
+description = "Welcome KCD Beijing 2026"
+template = "community.html"
+page_template = "community.html"
+[extra]
+cards = [
+    { icon = "icon-users.svg", title = "KCD Beijing 🇨🇳", description = "Thanks for visiting Valkey at KCD Beijing 2026. Learn how you can use Valkey in your cloud native applications for caching, session management, real-time analytics, and more.", links = [
+    { url = "https://community.cncf.io/events/details/cncf-kcd-beijing-presents-kcd-beijing-vllm-2026/", text = "KCD Beijing 2026" }
+  ] },
+]
++++
+
+# Welcome KCD Beijing 2026
+## How to Contribute with us?
+We welcome your involvement in the Valkey community! Here are several ways you can contribute:


### PR DESCRIPTION
### Description

Add community event page for KCD Beijing 2026. This creates a new landing page for visitors coming from the Kubernetes Community Days Beijing 2026 event, providing information about Valkey and how to get involved with the community. The page follows the same structure as other community event pages and links to the official CNCF event page.
 
### Issues Resolved

<!-- List any issues this PR will resolve. -->
closes #483 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
