### PR TITLE
Add events page intro (meetup, asana form), new events, and sort order

### DIFF
--- a/content/events/bay-area-opensearch-valkey-meetup-2026.md
+++ b/content/events/bay-area-opensearch-valkey-meetup-2026.md
@@ -1,0 +1,9 @@
++++
+title = "Bay Area OpenSearch + Valkey Meetup - April 2026"
+date = 2026-04-20
+
+[extra]
+event_type = "third-party"
+location = "San Francisco, CA, USA"
+external_url = "https://builder.aws.com/content/3BM4ZJR7CsJiD7kytzRthwa3o9G/opensearch-project-and-valkey-bay-area-meetup-april-2026"
++++

--- a/content/events/bay-area-opensearch-valkey-meetup-2026.md
+++ b/content/events/bay-area-opensearch-valkey-meetup-2026.md
@@ -1,6 +1,6 @@
 +++
 title = "Bay Area OpenSearch + Valkey Meetup - April 2026"
-date = 2026-04-20
+date = 2026-04-20 01:01:01
 
 [extra]
 event_type = "third-party"

--- a/content/events/laracon-us-2026.md
+++ b/content/events/laracon-us-2026.md
@@ -1,0 +1,9 @@
++++
+title = "Laracon US 2026"
+date = 2026-07-28
+
+[extra]
+event_type = "third-party"
+location = "Boston, MA, USA"
+external_url = "https://laracon.us/"
++++

--- a/content/events/laracon-us-2026.md
+++ b/content/events/laracon-us-2026.md
@@ -1,6 +1,6 @@
 +++
 title = "Laracon US 2026"
-date = 2026-07-28
+date = 2026-07-28 01:01:01
 
 [extra]
 event_type = "third-party"

--- a/content/events/ossummit-na-2026.md
+++ b/content/events/ossummit-na-2026.md
@@ -1,0 +1,9 @@
++++
+title = "Open Source Summit North America 2026"
+date = 2026-05-18
+
+[extra]
+event_type = "third-party"
+location = "Minneapolis, MN, USA"
+external_url = "https://events.linuxfoundation.org/open-source-summit-north-america/"
++++

--- a/content/events/ossummit-na-2026.md
+++ b/content/events/ossummit-na-2026.md
@@ -1,6 +1,6 @@
 +++
 title = "Open Source Summit North America 2026"
-date = 2026-05-18
+date = 2026-05-18 01:01:01
 
 [extra]
 event_type = "third-party"

--- a/content/events/percona-live-2026.md
+++ b/content/events/percona-live-2026.md
@@ -1,0 +1,9 @@
++++
+title = "Percona Live 2026"
+date = 2026-05-27
+
+[extra]
+event_type = "third-party"
+location = "Mountain View, CA, USA"
+external_url = "https://perconalive.com/2026-usa/"
++++

--- a/content/events/percona-live-2026.md
+++ b/content/events/percona-live-2026.md
@@ -1,6 +1,6 @@
 +++
 title = "Percona Live 2026"
-date = 2026-05-27
+date = 2026-05-27 01:01:01
 
 [extra]
 event_type = "third-party"

--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -2441,6 +2441,12 @@ blockquote {
   padding: 2rem 20px;
 }
 
+.events-intro {
+  text-align: center;
+  max-width: 800px;
+  margin: 0 auto 2rem;
+}
+
 .body main:has(.events-calendar) {
   padding-left: 0;
   padding-right: 0;

--- a/templates/events.html
+++ b/templates/events.html
@@ -6,6 +6,11 @@
 
 {% block main_content %}
 
+<div class="events-intro" style="text-align: center; max-width: 800px; margin: 0 auto 2rem;">
+  <p>Come meet us at an upcoming Valkey event!</p>
+  <p>Get involved: <a href="/community/meetup-groups/">Host a Meetup</a> | <a href="https://form.asana.com/?k=FA6ZlbUBbiaE4b7LJ9EXqQ&amp;d=9283783873717">Share an event</a></p>
+</div>
+
 <div class="events-calendar">
   <div class="events-legend">
     <span class="legend-item"><span class="legend-dot first-party"></span> Valkey Events</span>
@@ -129,13 +134,22 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   // Render all event cards once
-  var allEvents = events.slice().sort(function(a, b) { return b.date.localeCompare(a.date); });
+  var today = new Date().toISOString().substring(0, 10);
+  var currentMonth = today.substring(0, 7);
+  var thisMonth = events.filter(function(e) { return e.date.substring(0, 7) === currentMonth && e.date >= today; })
+                        .sort(function(a, b) { return a.date.localeCompare(b.date); });
+  var upcoming = events.filter(function(e) { return e.date > today && e.date.substring(0, 7) !== currentMonth; })
+                       .sort(function(a, b) { return a.date.localeCompare(b.date); });
+  var past = events.filter(function(e) { return e.date < today; })
+                   .sort(function(a, b) { return b.date.localeCompare(a.date); });
+ var allEvents = thisMonth.concat(upcoming).concat(past);
+
   var listHtml = '';
   allEvents.forEach(function(e) {
     var dateObj = new Date(e.date + 'T00:00:00');
     var dateStr = monthNames[dateObj.getMonth()] + ' ' + dateObj.getDate() + ', ' + dateObj.getFullYear();
     var eventMonth = e.date.substring(0, 7);
-    var today = new Date().toISOString().substring(0, 10);
+   // var today = new Date().toISOString().substring(0, 10);
     listHtml += '<div class="event-card' + (e.date < today ? ' past' : '') + '" data-month="' + eventMonth + '">' +
       '<span class="event-card-badge ' + e.type + '">' + (e.type === 'first-party' ? 'Valkey Event' : 'Third Party') + '</span>' +
       '<h3><a href="' + e.url + '">' + e.title + '</a></h3>' +

--- a/templates/events.html
+++ b/templates/events.html
@@ -134,7 +134,10 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   // Render all event cards once
-  var today = new Date().toISOString().substring(0, 10);
+  var nowLocal = new Date();
+  var today = nowLocal.getFullYear() + '-' +
+              String(nowLocal.getMonth() + 1).padStart(2, '0') + '-' +
+              String(nowLocal.getDate()).padStart(2, '0');
   var currentMonth = today.substring(0, 7);
   var thisMonthUpcoming = events.filter(function(e) { return e.date.substring(0, 7) === currentMonth && e.date >= today; })
                         .sort(function(a, b) { return a.date.localeCompare(b.date); });
@@ -149,12 +152,17 @@ document.addEventListener('DOMContentLoaded', function() {
     var dateObj = new Date(e.date + 'T00:00:00');
     var dateStr = monthNames[dateObj.getMonth()] + ' ' + dateObj.getDate() + ', ' + dateObj.getFullYear();
     var eventMonth = e.date.substring(0, 7);
-   
     listHtml += '<div class="event-card' + (e.date < today ? ' past' : '') + '" data-month="' + eventMonth + '">' +
       '<span class="event-card-badge ' + e.type + '">' + (e.type === 'first-party' ? 'Valkey Event' : 'Third Party') + '</span>' +
       '<h3><a href="' + e.url + '">' + e.title + '</a></h3>' +
       '<p class="event-card-date">' + dateStr + '</p>' +
-      (e.location ? '<p class="event-card-location"><a href="' + e.locationUrl + '" target="_blank">' + e.location + '</a></p>' : '') +
+      (e.location
+        ? '<p class="event-card-location">' +
+            (e.locationUrl
+              ? '<a href="' + e.locationUrl + '" target="_blank" rel="noopener noreferrer">' + e.location + '</a>'
+              : e.location) +
+          '</p>'
+        : '') +
       '</div>';
   });
   document.getElementById('events-list').innerHTML = listHtml;

--- a/templates/events.html
+++ b/templates/events.html
@@ -6,7 +6,7 @@
 
 {% block main_content %}
 
-<div class="events-intro" style="text-align: center; max-width: 800px; margin: 0 auto 2rem;">
+<div class="events-intro">
   <p>Come meet us at an upcoming Valkey event!</p>
   <p>Get involved: <a href="/community/meetup-groups/">Host a Meetup</a> | <a href="https://form.asana.com/?k=FA6ZlbUBbiaE4b7LJ9EXqQ&amp;d=9283783873717">Share an event</a></p>
 </div>
@@ -136,20 +136,20 @@ document.addEventListener('DOMContentLoaded', function() {
   // Render all event cards once
   var today = new Date().toISOString().substring(0, 10);
   var currentMonth = today.substring(0, 7);
-  var thisMonth = events.filter(function(e) { return e.date.substring(0, 7) === currentMonth && e.date >= today; })
+  var thisMonthUpcoming = events.filter(function(e) { return e.date.substring(0, 7) === currentMonth && e.date >= today; })
                         .sort(function(a, b) { return a.date.localeCompare(b.date); });
   var upcoming = events.filter(function(e) { return e.date > today && e.date.substring(0, 7) !== currentMonth; })
                        .sort(function(a, b) { return a.date.localeCompare(b.date); });
   var past = events.filter(function(e) { return e.date < today; })
                    .sort(function(a, b) { return b.date.localeCompare(a.date); });
- var allEvents = thisMonth.concat(upcoming).concat(past);
+  var allEvents = thisMonthUpcoming.concat(upcoming).concat(past);
 
   var listHtml = '';
   allEvents.forEach(function(e) {
     var dateObj = new Date(e.date + 'T00:00:00');
     var dateStr = monthNames[dateObj.getMonth()] + ' ' + dateObj.getDate() + ', ' + dateObj.getFullYear();
     var eventMonth = e.date.substring(0, 7);
-   // var today = new Date().toISOString().substring(0, 10);
+   
     listHtml += '<div class="event-card' + (e.date < today ? ' past' : '') + '" data-month="' + eventMonth + '">' +
       '<span class="event-card-badge ' + e.type + '">' + (e.type === 'first-party' ? 'Valkey Event' : 'Third Party') + '</span>' +
       '<h3><a href="' + e.url + '">' + e.title + '</a></h3>' +


### PR DESCRIPTION
### Description

Linked the form to add more events + linked the meetup charter. Also added more upcoming events like Percona Live, Laracon US, etc. 
 
### Issues Resolved

n/a

### Check List
- [ X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events page now includes an intro section with links to host meetups and share events
  * Event listing reordered: current-month upcoming, other future months, then past events (based on local date)

* **Documentation**
  * Added four third-party events: Bay Area OpenSearch + Valkey Meetup, Laracon US 2026, Open Source Summit NA 2026, Percona Live 2026

* **Style**
  * Centered and constrained intro text for the Events page

* **Accessibility/Security**
  * External event links open in a new tab with safe link attributes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey-io.github.io/pull/504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->