### PR TITLE
Add Valkey GLIDE C# client to clients page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -36,7 +36,7 @@ button_url = "/commands"
 [[extra.documentation_cards]]
 title = "Clients"
 description = "Official Valkey client libraries include support for:"
-features = ["Python", "Java", "Go", "Node.js", "PHP"]
+features = ["Python", "Java", "Go", "Node.js", "PHP", "C#"]
 button_text = "Learn More"
 button_url = "/clients"
 

--- a/content/clients/_index.md
+++ b/content/clients/_index.md
@@ -14,7 +14,8 @@ recommended_clients_paths = [
     "/go/valkey-go.json",
     "/php/phpredis.json",
     "/php/predis.json",
-    "/swift/valkey-swift.json"
+    "/swift/valkey-swift.json",
+    "/csharp/valkey-GLIDE.json"
     ] 
 
 client_fields =[

--- a/templates/macros/docs.html
+++ b/templates/macros/docs.html
@@ -70,6 +70,8 @@
 {% macro format_language(language) %}
     {% if language == "php" %}
         {{ language | upper }}
+    {% elif language == "csharp" %}
+        C#
     {% else %}
         {{ language | title }}
     {% endif %}


### PR DESCRIPTION
### Description

Adds the [Valkey GLIDE C#](https://github.com/valkey-io/valkey-glide-csharp) client to the website, following its [v1.0.0 release](https://github.com/valkey-io/valkey-glide-csharp/releases/tag/v1.0.0).

Changes:

- Added `"/csharp/valkey-GLIDE.json"` to the `recommended_clients_paths` list in `content/clients/_index.md` so the C# GLIDE client appears on the `/clients/` page.
- Added a `csharp` case to the `format_language` macro in `templates/macros/docs.html` to render the language name as "C#" instead of "Csharp".
- Added "C#" to the homepage clients card feature list in `content/_index.md`.

### Issues Resolved

:white_circle: None

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.

### Related

- The corresponding client JSON data file (`clients/csharp/valkey-GLIDE.json`) is being added to `valkey-doc` via https://github.com/valkey-io/valkey-doc/pull/430.