### PR TITLE
Add workflow to auto-assign technical-blog-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*   @AMoo-Miki @madolson @stockholmux
+*              @AMoo-Miki @madolson @stockholmux
+/templates/    @stockholmux

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 *              @madolson @stockholmux
-/content/      @valkey-io/content-creators
+/content/blog/       @valkey-io/content-creators
+/content/events/     @valkey-io/content-creators
+/content/community/  @valkey-io/content-creators
+/content/authors/    @valkey-io/content-creators
 /templates/    @stockholmux

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 *              @AMoo-Miki @madolson @stockholmux
+/content/      @valkey-io/content-creators
 /templates/    @stockholmux

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-*              @AMoo-Miki @madolson @stockholmux
+*              @madolson @stockholmux
 /content/      @valkey-io/content-creators
 /templates/    @stockholmux

--- a/.github/workflows/assign-blog-reviewers.yml
+++ b/.github/workflows/assign-blog-reviewers.yml
@@ -39,7 +39,6 @@ jobs:
 
             const technicalTypes = ['Technical Deep Dive', 'Announcements'];
             let needsTechnical = false;
-            let needsContent = false;
 
             for (const file of newBlogFiles) {
               // Fetch file content from the PR head SHA via the API (safe for fork PRs)
@@ -64,18 +63,11 @@ jobs:
 
               if (technicalTypes.includes(blogType)) {
                 needsTechnical = true;
-              } else {
-                needsContent = true;
               }
             }
 
-            // Assign the appropriate reviewer teams
-            const teams = [];
-            if (needsTechnical) teams.push('technical-blog-reviewers');
-            if (needsContent) teams.push('content-creators');
-
-            if (teams.length === 0) {
-              core.info('No new blog posts with recognized types, skipping.');
+            if (!needsTechnical) {
+              core.info('No technical/announcement blog posts found, skipping.');
               return;
             }
 
@@ -84,9 +76,9 @@ jobs:
                 owner,
                 repo,
                 pull_number: pr_number,
-                team_reviewers: teams,
+                team_reviewers: ['technical-blog-reviewers'],
               });
-              core.info(`Requested review from: ${teams.join(', ')}`);
+              core.info('Requested review from technical-blog-reviewers.');
             } catch (error) {
               core.warning(`Failed to request reviewers: ${error.message}`);
             }

--- a/.github/workflows/assign-blog-reviewers.yml
+++ b/.github/workflows/assign-blog-reviewers.yml
@@ -72,7 +72,7 @@ jobs:
             // Assign the appropriate reviewer teams
             const teams = [];
             if (needsTechnical) teams.push('technical-blog-reviewers');
-            if (needsContent) teams.push('content-approvers');
+            if (needsContent) teams.push('content-creators');
 
             if (teams.length === 0) {
               core.info('No new blog posts with recognized types, skipping.');

--- a/.github/workflows/assign-blog-reviewers.yml
+++ b/.github/workflows/assign-blog-reviewers.yml
@@ -51,17 +51,24 @@ jobs:
 
               const content = Buffer.from(data.content, 'base64').toString('utf-8');
 
-              // Extract blog_type from TOML front matter (between +++ fences)
-              const match = content.match(/blog_type\s*=\s*\["([^"]+)"\]/);
-              if (!match) {
-                core.info(`${file.filename}: no blog_type found, skipping.`);
-                continue;
+              // Extract blog_type from TOML (+++ fences) or YAML (--- fences) front matter
+              let blogTypes = [];
+              const tomlMatch = content.match(/blog_type\s*=\s*\[([^\]]+)\]/);
+              const yamlMatch = content.match(/blog_type:\s*\n((?:\s*-\s*.+\n)+)/);
+              if (tomlMatch) {
+                blogTypes = [...tomlMatch[1].matchAll(/"([^"]+)"/g)].map(m => m[1]);
+              } else if (yamlMatch) {
+                blogTypes = [...yamlMatch[1].matchAll(/-\s*"?([^"\n]+)"?/g)].map(m => m[1].trim());
               }
 
-              const blogType = match[1];
-              core.info(`${file.filename}: blog_type = "${blogType}"`);
+              if (blogTypes.length === 0) {
+                core.setFailed(`${file.filename}: could not parse blog_type from front matter.`);
+                return;
+              }
 
-              if (technicalTypes.includes(blogType)) {
+              core.info(`${file.filename}: blog_type = ${JSON.stringify(blogTypes)}`);
+
+              if (blogTypes.some(t => technicalTypes.includes(t))) {
                 needsTechnical = true;
               }
             }

--- a/.github/workflows/assign-blog-reviewers.yml
+++ b/.github/workflows/assign-blog-reviewers.yml
@@ -37,8 +37,9 @@ jobs:
               return;
             }
 
-            const targetTypes = ['Technical Deep Dive', 'Announcements'];
-            let shouldAssign = false;
+            const technicalTypes = ['Technical Deep Dive', 'Announcements'];
+            let needsTechnical = false;
+            let needsContent = false;
 
             for (const file of newBlogFiles) {
               // Fetch file content from the PR head SHA via the API (safe for fork PRs)
@@ -61,25 +62,31 @@ jobs:
               const blogType = match[1];
               core.info(`${file.filename}: blog_type = "${blogType}"`);
 
-              if (targetTypes.includes(blogType)) {
-                shouldAssign = true;
+              if (technicalTypes.includes(blogType)) {
+                needsTechnical = true;
+              } else {
+                needsContent = true;
               }
             }
 
-            if (!shouldAssign) {
-              core.info('No matching blog types found, skipping reviewer assignment.');
+            // Assign the appropriate reviewer teams
+            const teams = [];
+            if (needsTechnical) teams.push('technical-blog-reviewers');
+            if (needsContent) teams.push('content-approvers');
+
+            if (teams.length === 0) {
+              core.info('No new blog posts with recognized types, skipping.');
               return;
             }
 
-            // Request review from the team
             try {
               await github.rest.pulls.requestReviewers({
                 owner,
                 repo,
                 pull_number: pr_number,
-                team_reviewers: ['technical-blog-reviewers'],
+                team_reviewers: teams,
               });
-              core.info('Requested review from technical-blog-reviewers.');
+              core.info(`Requested review from: ${teams.join(', ')}`);
             } catch (error) {
               core.warning(`Failed to request reviewers: ${error.message}`);
             }

--- a/.github/workflows/assign-blog-reviewers.yml
+++ b/.github/workflows/assign-blog-reviewers.yml
@@ -51,20 +51,13 @@ jobs:
 
               const content = Buffer.from(data.content, 'base64').toString('utf-8');
 
-              // Extract blog_type from TOML (+++ fences) or YAML (--- fences) front matter
-              let blogTypes = [];
+              // Extract blog_type from TOML front matter (between +++ fences)
               const tomlMatch = content.match(/blog_type\s*=\s*\[([^\]]+)\]/);
-              const yamlMatch = content.match(/blog_type:\s*\n((?:\s*-\s*.+\n)+)/);
-              if (tomlMatch) {
-                blogTypes = [...tomlMatch[1].matchAll(/"([^"]+)"/g)].map(m => m[1]);
-              } else if (yamlMatch) {
-                blogTypes = [...yamlMatch[1].matchAll(/-\s*"?([^"\n]+)"?/g)].map(m => m[1].trim());
-              }
-
-              if (blogTypes.length === 0) {
-                core.setFailed(`${file.filename}: could not parse blog_type from front matter.`);
+              if (!tomlMatch) {
+                core.setFailed(`${file.filename}: could not parse blog_type from TOML front matter. Ensure the post uses TOML (not YAML) frontmatter.`);
                 return;
               }
+              const blogTypes = [...tomlMatch[1].matchAll(/"([^"]+)"/g)].map(m => m[1]);
 
               core.info(`${file.filename}: blog_type = ${JSON.stringify(blogTypes)}`);
 

--- a/.github/workflows/assign-blog-reviewers.yml
+++ b/.github/workflows/assign-blog-reviewers.yml
@@ -1,0 +1,85 @@
+name: Assign blog reviewers
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+    paths:
+      - 'content/blog/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for new technical/announcement blog posts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr_number = context.payload.pull_request.number;
+            const head_sha = context.payload.pull_request.head.sha;
+
+            // Get files changed in the PR
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: pr_number, per_page: 100 }
+            );
+
+            // Filter for newly added .md files under content/blog/
+            const newBlogFiles = files.filter(
+              f => f.status === 'added' && f.filename.startsWith('content/blog/') && f.filename.endsWith('.md')
+            );
+
+            if (newBlogFiles.length === 0) {
+              core.info('No new blog files added, skipping.');
+              return;
+            }
+
+            const targetTypes = ['Technical Deep Dive', 'Announcements'];
+            let shouldAssign = false;
+
+            for (const file of newBlogFiles) {
+              // Fetch file content from the PR head SHA via the API (safe for fork PRs)
+              const { data } = await github.rest.repos.getContent({
+                owner: context.payload.pull_request.head.repo.owner.login,
+                repo: context.payload.pull_request.head.repo.name,
+                path: file.filename,
+                ref: head_sha,
+              });
+
+              const content = Buffer.from(data.content, 'base64').toString('utf-8');
+
+              // Extract blog_type from TOML front matter (between +++ fences)
+              const match = content.match(/blog_type\s*=\s*\["([^"]+)"\]/);
+              if (!match) {
+                core.info(`${file.filename}: no blog_type found, skipping.`);
+                continue;
+              }
+
+              const blogType = match[1];
+              core.info(`${file.filename}: blog_type = "${blogType}"`);
+
+              if (targetTypes.includes(blogType)) {
+                shouldAssign = true;
+              }
+            }
+
+            if (!shouldAssign) {
+              core.info('No matching blog types found, skipping reviewer assignment.');
+              return;
+            }
+
+            // Request review from the team
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number: pr_number,
+                team_reviewers: ['technical-blog-reviewers'],
+              });
+              core.info('Requested review from technical-blog-reviewers.');
+            } catch (error) {
+              core.warning(`Failed to request reviewers: ${error.message}`);
+            }

--- a/.github/workflows/assign-blog-reviewers.yml
+++ b/.github/workflows/assign-blog-reviewers.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for new technical/announcement blog posts
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/content/blog/README
+++ b/content/blog/README
@@ -51,6 +51,12 @@ The `blog_type` taxonomy is defined in `config.toml`. Current values:
 
 To add a new type, add a post using it and update `sass/_valkey.scss` (badge color) and this README.
 
+## Review process
+
+PRs that add a new blog post with `blog_type` of **Technical Deep Dive** or **Announcements** will automatically have the `@valkey-io/technical-blog-reviewers` team requested as reviewers. Other post types are reviewed by the CODEOWNERS.
+
+All commits must be signed off per the [DCO](https://developercertificate.org/) using `git commit --signoff`.
+
 ## File naming
 
 Use the format `YYYY-MM-DD-slug.md` (or `YYYY-MM-DD-slug/index.md` for posts with assets).

--- a/content/blog/README
+++ b/content/blog/README
@@ -53,7 +53,7 @@ To add a new type, add a post using it and update `sass/_valkey.scss` (badge col
 
 ## Review process
 
-PRs that add a new blog post with `blog_type` of **Technical Deep Dive** or **Announcements** will automatically have the `@valkey-io/technical-blog-reviewers` team requested as reviewers. All other blog types will have `@valkey-io/content-creators` requested instead.
+PRs that add a new blog post with `blog_type` of **Technical Deep Dive** or **Announcements** will automatically have the `@valkey-io/technical-blog-reviewers` team requested as an additional reviewer. All content changes are reviewed by `@valkey-io/content-creators` via CODEOWNERS.
 
 All commits must be signed off per the [DCO](https://developercertificate.org/) using `git commit --signoff`.
 

--- a/content/blog/README
+++ b/content/blog/README
@@ -53,7 +53,7 @@ To add a new type, add a post using it and update `sass/_valkey.scss` (badge col
 
 ## Review process
 
-PRs that add a new blog post with `blog_type` of **Technical Deep Dive** or **Announcements** will automatically have the `@valkey-io/technical-blog-reviewers` team requested as reviewers. Other post types are reviewed by the CODEOWNERS.
+PRs that add a new blog post with `blog_type` of **Technical Deep Dive** or **Announcements** will automatically have the `@valkey-io/technical-blog-reviewers` team requested as reviewers. All other blog types will have `@valkey-io/content-approvers` requested instead.
 
 All commits must be signed off per the [DCO](https://developercertificate.org/) using `git commit --signoff`.
 

--- a/content/blog/README
+++ b/content/blog/README
@@ -53,7 +53,7 @@ To add a new type, add a post using it and update `sass/_valkey.scss` (badge col
 
 ## Review process
 
-PRs that add a new blog post with `blog_type` of **Technical Deep Dive** or **Announcements** will automatically have the `@valkey-io/technical-blog-reviewers` team requested as reviewers. All other blog types will have `@valkey-io/content-approvers` requested instead.
+PRs that add a new blog post with `blog_type` of **Technical Deep Dive** or **Announcements** will automatically have the `@valkey-io/technical-blog-reviewers` team requested as reviewers. All other blog types will have `@valkey-io/content-creators` requested instead.
 
 All commits must be signed off per the [DCO](https://developercertificate.org/) using `git commit --signoff`.
 


### PR DESCRIPTION
### Description

Adds a GitHub Actions workflow that automatically requests review from `@valkey-io/technical-blog-reviewers` when a PR adds a new blog post with `blog_type` of "Technical Deep Dive" or "Announcements".

This also updates code owners a bit. Removes some files that don't need Madelyn/Kyle's review while keeping kyle assigned to templates. All content get's content creators added (we can change the name, but that was the historical group that does blogs/events)

**How it works:**
1. Triggers on `pull_request_target` (opened/synchronize) when files under `content/blog/**` change
2. Uses the GitHub API to detect newly added `.md` files (ignores modifications to existing posts)
3. Fetches each new file's content and parses the TOML front matter for `blog_type`
4. Requests review from `technical-blog-reviewers` only if a matching type is found

**Design decisions:**
- Uses `pull_request_target` so it works for PRs from forks (most external contributors)
- Reads file content via the GitHub API only — no checkout of PR code (safe for `pull_request_target`)
- Regex-based front matter parsing — the `blog_type` format is consistent across all 44 existing blog posts
- Gracefully handles missing `blog_type` and API errors

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.