### PR TITLE
Update website for version 9.1.0-rc2

### DIFF
--- a/content/download/releases/v9-1-0-rc2.md
+++ b/content/download/releases/v9-1-0-rc2.md
@@ -1,0 +1,31 @@
+---
+title: "9.1.0-rc2"
+date: 2026-04-28
+extra:
+    tag: "9.1.0-rc2"
+    artifact_source: https://download.valkey.io/releases/
+    artifact_fname: "valkey"
+    container_registry:
+        -
+            name: "Docker Hub"
+            link: https://hub.docker.com/r/valkey/valkey/
+            id: "valkey/valkey"
+            tags:
+                - "9.1"
+                - "9.1-trixie"
+                - "9.1-alpine"
+                - "9.1-alpine3.23"
+    packages:
+
+    artifacts:
+        -   distro: jammy
+            arch:
+                -   arm64
+                -   x86_64
+        -   distro: noble
+            arch:
+                -   arm64
+                -   x86_64
+---
+
+Valkey 9.1.0-rc2 Release


### PR DESCRIPTION
This pull request updates the valkey website for the new release 9.1.0-rc2.

Changes:
- Updated downloads page with new release information


This pull request is created automatically by the [Valkey-Release-Automation](https://github.com/valkey-io/valkey-release-automation)