### PR TITLE
Update website for version 9.0.4

### DIFF
--- a/content/download/releases/v9-0-4.md
+++ b/content/download/releases/v9-0-4.md
@@ -1,0 +1,31 @@
+---
+title: "9.0.4"
+date: 2026-05-06
+extra:
+    tag: "9.0.4"
+    artifact_source: https://download.valkey.io/releases/
+    artifact_fname: "valkey"
+    container_registry:
+        -
+            name: "Docker Hub"
+            link: https://hub.docker.com/r/valkey/valkey/
+            id: "valkey/valkey"
+            tags:
+                - "9.0.4"
+                - "9.0.4-trixie"
+                - "9.0.4-alpine"
+                - "9.0.4-alpine3.23"
+    packages:
+
+    artifacts:
+        -   distro: jammy
+            arch:
+                -   arm64
+                -   x86_64
+        -   distro: noble
+            arch:
+                -   arm64
+                -   x86_64
+---
+
+Valkey 9.0.4 Release

--- a/content/try-valkey/_index.md
+++ b/content/try-valkey/_index.md
@@ -2,9 +2,9 @@
 title = "Try Valkey"
 template = "valkey-try-me.html"
 [extra]
-state_file = "https://download.valkey.io/try-me-valkey/9.0.3/states/state.bin.gz"
-filesystem_base_url = "https://download.valkey.io/try-me-valkey/9.0.3/fs/alpine-rootfs-flat"
-filesystem_base_fs = "https://download.valkey.io/try-me-valkey/9.0.3/fs/alpine-fs.json"
+state_file = "https://download.valkey.io/try-me-valkey/9.0.4/states/state.bin.gz"
+filesystem_base_url = "https://download.valkey.io/try-me-valkey/9.0.4/fs/alpine-rootfs-flat"
+filesystem_base_fs = "https://download.valkey.io/try-me-valkey/9.0.4/fs/alpine-fs.json"
 +++
 
 


### PR DESCRIPTION
This pull request updates the valkey website for the new release 9.0.4.

Changes:
- Updated downloads page with new release information
- Updated Try Valkey page to use version 9.0.4

This pull request is created automatically by the [Valkey-Release-Automation](https://github.com/valkey-io/valkey-release-automation)