### PR TITLE
Add link for Valkey Admin

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -10,4 +10,5 @@ body_class=  "blocks-page"
 * [Command Reference](/commands/) A categorized listing of all Valkey commands
 * [Documentation by topic](/topics/) In-depth documentation covering a wide variety of operational and usage subjects
 * [Client Libraries](/clients/) An overview of recommended Valkey clients and their features.
+* [Valkey Admin](http://valkey-admin.valkey.io/) An intuitive visual interface to monitor, manage, and interact with your Valkey deployments.
 


### PR DESCRIPTION
### Description

This change adds a link for Valkey Admin documentation at http://valkey-admin.valkey.io/. 
### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
