### PR TITLE
test: add auto-author-assign with Valkeyrie Bot

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,20 @@
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.VALKEYRIE_BOT_APP_ID }}
+          private-key: ${{ secrets.VALKEYRIE_BOT_PRIVATE_KEY }}
+
+      - uses: toshimaru/auto-author-assign@4d585cc37690897bd9015942ed6e766aa7cdb97f # v3.0.1
+        with:
+          github_token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Testing the auto-author-assign workflow using the Valkeyrie Bot app token instead of the default GITHUB_TOKEN. Once merged, opening a second PR will trigger the workflow to verify it works. Will delete after testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated author assignment workflow for pull requests upon creation and reopening.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey-io.github.io/pull/549)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->