### PR TITLE
Use Valkeyrie Bot for assign-blog-reviewers workflow

### DIFF
--- a/.github/workflows/assign-blog-reviewers.yml
+++ b/.github/workflows/assign-blog-reviewers.yml
@@ -6,16 +6,21 @@ on:
     paths:
       - 'content/blog/**'
 
-permissions:
-  pull-requests: write
-
 jobs:
   assign-reviewers:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.VALKEYRIE_BOT_APP_ID }}
+          private-key: ${{ secrets.VALKEYRIE_BOT_PRIVATE_KEY }}
+
       - name: Check for new technical/announcement blog posts
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
             const pr_number = context.payload.pull_request.number;


### PR DESCRIPTION
The default GITHUB_TOKEN lacks permission to request team reviewers on PRs from forks. Switch to the Valkeyrie Bot app token which has the necessary org-level access.

Changes:
- Remove top-level `permissions` block (unnecessary with app token)
- Add `generate-token` step using `actions/create-github-app-token`
- Pass generated token to `actions/github-script` via `github-token`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the blog reviewer assignment workflow's authentication mechanism to improve security and reliability of the automated process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey-io.github.io/pull/550)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->