### PR TITLE
Remove intro paragraph above demo video

### DIFF
--- a/content/blog/2026-05-12-introducing-valkey-admin-1-0-visual-cluster-management-for-valkey/index.md
+++ b/content/blog/2026-05-12-introducing-valkey-admin-1-0-visual-cluster-management-for-valkey/index.md
@@ -96,15 +96,6 @@ The `examples/` directory in the repo contains deployment guides for Docker, Kub
 
 ## Demo
 
-A visual cluster management tool for Valkey — real-time dashboards, topology maps, key browser, hot key detection, and command logs, all in one place.
-
-What's inside:
-- Real-time cluster dashboards over WebSocket
-- Topology visualization with per-node detail
-- Key browser across 7 data types
-- Hot key detection with minimal cluster overhead
-- Command logs for slow commands and large requests
-
 <iframe width="560" height="315" src="https://www.youtube.com/embed/-ypi0VkKaIE" title="Valkey Admin 1.0 Release" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Join the community


### PR DESCRIPTION
Address review feedback on #548 from @madolson and @crystalphamLF : the intro paragraph + bulleted feature list above the embedded video duplicated content from the blog header. Removed so the video stands on its own under the Demo heading. cc: @rlunar 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the Valkey Admin 1.0 release blog post by removing promotional content to provide a more direct path to the demonstration video.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey-io.github.io/pull/552)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->