### PR TITLE
Add valkey-GLIDE PHP client to recommended clients list

### DIFF
--- a/content/clients/_index.md
+++ b/content/clients/_index.md
@@ -14,6 +14,7 @@ recommended_clients_paths = [
     "/go/valkey-go.json",
     "/php/phpredis.json",
     "/php/predis.json",
+    "/php/valkey-GLIDE.json",
     "/swift/valkey-swift.json",
     "/csharp/valkey-GLIDE.json"
     ] 


### PR DESCRIPTION
## Description

Adds the Valkey GLIDE PHP client to the recommended clients list on the [clients page](https://valkey.io/clients/#php).

This is the companion change to valkey-io/valkey-doc#443, which adds the `clients/php/valkey-GLIDE.json` metadata file. This PR ensures the website renders the new entry by including it in `recommended_clients_paths`.

## Changes

- Added `/php/valkey-GLIDE.json` to `recommended_clients_paths` in
  `content/clients/_index.md`

## Testing

<img width="1725" height="1043" alt="Screenshot 2026-05-22 at 22 17 07" src="https://github.com/user-attachments/assets/a7cb1df2-1006-4f27-b5f1-2360a0cd63cf" />
