### PR TITLE
Fix CI to test merge result instead of fork branch in isolation

### DIFF
--- a/.github/workflows/zola-deploy.yml
+++ b/.github/workflows/zola-deploy.yml
@@ -21,12 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: >-
-            ${{ github.event_name == 'pull_request' &&
-                github.head_ref || 'main' }}
-          repository: >-
-            ${{ github.event_name == 'pull_request' &&
-                github.event.pull_request.head.repo.full_name || 'valkey-io/valkey-io.github.io' }}
+          ref: ${{ github.event_name != 'pull_request' && 'main' || '' }}
           path: website
 
       - name: Checkout valkey-doc


### PR DESCRIPTION
The checkout step in `zola-deploy.yml` was explicitly checking out the PR's head ref from the fork repository. This means PRs from stale forks would fail if they depended on any config changes in main, even though the actual merge result would build fine.

This removes the explicit `ref`/`repository` overrides and lets `actions/checkout` use its default behavior, which checks out `refs/pull/N/merge` (the merge commit) for `pull_request` events. This is the standard pattern for CI workflows.

Fixes #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->