### PR TITLE
Add Contribute link to Community submenu

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -57,6 +57,7 @@
         <div class="has-submenu">
           <a role="menuitem" href="/community/">Community</a>
           <div class="submenu">
+            <a role="menuitem" href="/community/">Contribute</a>
             <a role="menuitem" href="/events/">Events</a>
           </div>
         </div>


### PR DESCRIPTION
Adds a 'Contribute' link under the Community dropdown menu that points to /community/ (the main community/contribute page). This makes the contribute page discoverable from the nav without requiring users to click the top-level Community link.