### PR TITLE
fix harbor blog post date

### DIFF
--- a/content/blog/2026-07-17-harbor-chose-valkey.md
+++ b/content/blog/2026-07-17-harbor-chose-valkey.md
@@ -1,6 +1,6 @@
 +++
 title = "Harbor Chose Valkey"
-date = 2026-07-29 01:01:01
+date = 2026-07-28 01:01:01
 description = "With v2.15.2, Harbor replaced Redis with Valkey as its internal cache backend. Here is why the CNCF graduated container registry made the switch and how you can run it today."
 authors = ["edithpuclla", "orlinvasilev"]
 [taxonomies]


### PR DESCRIPTION
### Description

There was a mixup on the publish date for the Harbor blog post. This corrects the date to the publish date.

 
### Issues Resolved

n/a

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
