### PR TITLE
Add a style guide to the blog contributing doc

### DIFF
--- a/CONTRIBUTING-BLOG-POST.md
+++ b/CONTRIBUTING-BLOG-POST.md
@@ -48,6 +48,7 @@ What do you want your readers to do next after they finish your blog post? The c
 You can even just invite readers to consume related content.
 7. Speak for yourself.
 Blog posts are attributed to a person, not the project, so feel free to have opinions and write in the first (I) or second (you) grammatical person.
+If the post has more than one author, use the plural: “we ran the benchmark”, not “I ran the benchmark”.
 Unless you have specific authority (and you probably don’t!), avoid speaking for groups of people.
 
 ### How to write it
@@ -61,6 +62,8 @@ Copy it as a starting point.
 Markdown joins the lines back into a paragraph, so nothing changes about how the post renders.
 GitHub anchors suggestions to lines, so a reviewer can rewrite one sentence instead of rewriting the paragraph.
 This is a convention for the source file, not a style directive: write sentences of whatever length the idea needs.
+    1. If you have already written a draft in paragraphs, `sed -E 's/([.!?]) +/\1\n/g' post.md` splits it for you.
+    It breaks on abbreviations like “e.g.”, so read the result before you commit it.
 2. Cut weasel words.
 "Significantly faster" and "various improvements" imply a claim without making one.
 Replace them with the number, name, or link they stood in for, or delete them.
@@ -68,6 +71,9 @@ Replace them with the number, name, or link they stood in for, or delete them.
     2. You can hedge when there is uncertainty, but say where it comes from: “we have not measured this on ARM”, not “this should probably be fine”.
 3. Make every claim checkable.
 Give numbers with their units and the setup that produced them, link behavior claims to a pull request or the docs, and name the version a behavior applies to.
+    1. When you link a line of source code, pin the link to a tag or a commit SHA.
+    A link into `unstable` points at a different line every time the branch moves.
+    On GitHub, press `y` while viewing a file to rewrite the URL to the current commit.
 4. Use the latest version of Valkey with default configurations when possible.
 Record the exact version you tested so the result stays reproducible after the next release.
 If you aren't running the latest version or the default configuration, discuss why.
@@ -78,15 +84,28 @@ If applicable, include a link to their github or blog profile.
 7. Write descriptive headings, not clever ones.
 Make sure each header is clear to the end user.
 Feel free to make creative jokes and puns, but not at the expense of reading for our global audience.
-8. Use primary instead of master, replica instead of slave, allowlist instead of whitelist, and denylist instead of blacklist.
+8. Use the term in the "Use this" column.
 This applies to prose, diagrams, and code you control.
-Keep the exact spelling where Valkey itself still uses the old term, such as the `SLAVEOF` command.
+Where Valkey itself still emits the old term, keep its exact spelling in code and output, and use the new term in the surrounding prose.
+
+    | Don't use | Use this | Notes |
+    | --- | --- | --- |
+    | master | primary | `SLAVEOF`, `master_repl_offset`, and `ROLE` still report `master` |
+    | slave | replica | `SLAVEOF`, `slave_read_only`, and `ROLE` still report `slave` |
+    | whitelist | allowlist | |
+    | blacklist | denylist | |
+    | QPS | RPS | Valkey serves commands, not queries; `valkey-benchmark` reports "requests per second" |
+
 9. Enclose commands in backticks and write them in uppercase, like `SET` and `XADD`.
 10. Enclose executable names, configs, and info fields in backticks and write them in lowercase, like `valkey-server` and `cluster-node-timeout`.
-11. Tag code blocks with a language so that they render correctly: write `bash`, `python`, or `text` immediately after the opening fence.
-12. Give images alt text that conveys what the reader would miss without the image, not just a caption of what is visible.
-For example, `![Throughput rises linearly to 8 threads, then flattens](/assets/media/pictures/scaling.png)` rather than `![benchmark chart](/assets/media/pictures/scaling.png)`.
-Use empty alt text (`![]`) for purely decorative images.
+11. Tag code blocks with a language so that they render and highlight correctly: write `bash`, `python`, or `text` immediately after the opening fence.
+The [Giallo grammar list](https://github.com/getzola/giallo?tab=readme-ov-file#built-in) has the tags Zola accepts.
+12. Write alt text using the [W3C alt decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/).
+The two cases that come up most in Valkey posts:
+    1. A chart, graph, or architecture diagram is a *complex* image, and alt text alone cannot carry it.
+    Put the information it conveys in the body of the post, where every reader gets it, and keep the alt text to a short identification such as `![Throughput against thread count](/assets/media/pictures/scaling.png)`.
+    If you find you have nothing to write in the body, the image is not carrying information worth showing.
+    2. Use empty alt text (`![]`) for a purely decorative image, and for one whose content the adjacent text already states in full.
 13. Expand an acronym on first use with the acronym in parentheses.
 
 ## Step 3: Write about yourself

--- a/CONTRIBUTING-BLOG-POST.md
+++ b/CONTRIBUTING-BLOG-POST.md
@@ -62,7 +62,7 @@ Markdown joins the lines back into a paragraph, so nothing changes about how the
 GitHub anchors suggestions to lines, so a reviewer can rewrite one sentence instead of rewriting the paragraph.
 This is a convention for the source file, not a style directive: write sentences of whatever length the idea needs.
 2. Cut weasel words.
-“Significantly faster” and “various improvements” imply a claim without making one.
+"Significantly faster" and "various improvements" imply a claim without making one.
 Replace them with the number, name, or link they stood in for, or delete them.
     1. The same goes for padding: “basically”, “quite”, “simply”, “very”, “actually”, “of course”.
     2. You can hedge when there is uncertainty, but say where it comes from: “we have not measured this on ARM”, not “this should probably be fine”.

--- a/CONTRIBUTING-BLOG-POST.md
+++ b/CONTRIBUTING-BLOG-POST.md
@@ -36,11 +36,13 @@ Aim for 500-1,200 words.
     1. If you start writing and realize that your post will be super long, consider refining your topic.
     2. Sometimes there are very good reasons to link multiple posts together, but length is not one; aim to make each post independent and not part of a series.
 3. Highly technical is fine but understand that [valkey.io](http://valkey.io/) is read by a variety of skill levels: the best posts make complex topics easy to understand.
+Start by setting context for technical readers who are unfamiliar with the topic.
 4. [Valkey.io](http://valkey.io/) is not a commercial space; you can write about services and products as long as a) you’re not actively selling/promoting and b) the subject matter is directly related to the use of Valkey.
     1. Acceptable Example: A post that describes the lessons learned about operating Valkey at scale gleaned from a Valkey service provider.
     2. Unacceptable Example: A post that describes the advantages of running Valkey through a specific service.
 5. Write about Valkey.
 There is a ton of things to say about Valkey without venturing into comparisons with other products and projects.
+Comparing Valkey against earlier Valkey versions is fine; head-to-head comparisons against other products belong on other platforms, not [valkey.io](http://valkey.io/).
 6. Have a call-to-action.
 What do you want your readers to do next after they finish your blog post? The call-to-action can be something like asking a users to contribute, try some sample code, or come to an event.
 You can even just invite readers to consume related content.
@@ -52,10 +54,13 @@ Unless you have specific authority (and you probably don’t!), avoid speaking f
 
 Reviewers use these as the basis for suggestions, so knowing them up front saves a round trip.
 This document follows them, so read its source as an example.
+[`content/blog/example-post.md.example`](content/blog/example-post.md.example) is a short post that applies every rule below, with frontmatter, a tagged code block, and an image with alt text.
+Copy it as a starting point.
 
 1. Put one sentence per line in the markdown source.
 Markdown joins the lines back into a paragraph, so nothing changes about how the post renders.
 GitHub anchors suggestions to lines, so a reviewer can rewrite one sentence instead of rewriting the paragraph.
+This is a convention for the source file, not a style directive: write sentences of whatever length the idea needs.
 2. Cut weasel words.
 “Significantly faster” and “various improvements” imply a claim without making one.
 Replace them with the number, name, or link they stood in for, or delete them.
@@ -63,8 +68,8 @@ Replace them with the number, name, or link they stood in for, or delete them.
     2. You can hedge when there is uncertainty, but say where it comes from: “we have not measured this on ARM”, not “this should probably be fine”.
 3. Make every claim checkable.
 Give numbers with their units and the setup that produced them, link behavior claims to a pull request or the docs, and name the version a behavior applies to.
-4. Use default or stock Valkey when possible.
-Run the latest version of Valkey with the default configuration.
+4. Use the latest version of Valkey with default configurations when possible.
+Record the exact version you tested so the result stays reproducible after the next release.
 If you aren't running the latest version or the default configuration, discuss why.
 5. Credit contributors by name when you describe their work.
 If applicable, include a link to their github or blog profile.
@@ -73,23 +78,28 @@ If applicable, include a link to their github or blog profile.
 7. Write descriptive headings, not clever ones.
 Make sure each header is clear to the end user.
 Feel free to make creative jokes and puns, but not at the expense of reading for our global audience.
-8. Use inclusive terminology in prose, diagrams, and code: primary and replica, allowlist and denylist.
-9. Use uppercase backticks for commands like `SET` and `XADD`.
-10. Use lowercase backticks when describing executable names, configs, and info fields like `valkey-server` and `cluster-node-timeout`.
-11. Tag code blocks with a language so that they render correctly.
-12. Give images alt text describing what they show to make them more inclusive.
+8. Use primary instead of master, replica instead of slave, allowlist instead of whitelist, and denylist instead of blacklist.
+This applies to prose, diagrams, and code you control.
+Keep the exact spelling where Valkey itself still uses the old term, such as the `SLAVEOF` command.
+9. Enclose commands in backticks and write them in uppercase, like `SET` and `XADD`.
+10. Enclose executable names, configs, and info fields in backticks and write them in lowercase, like `valkey-server` and `cluster-node-timeout`.
+11. Tag code blocks with a language so that they render correctly: write `bash`, `python`, or `text` immediately after the opening fence.
+12. Give images alt text that conveys what the reader would miss without the image, not just a caption of what is visible.
+For example, `![Throughput rises linearly to 8 threads, then flattens](/assets/media/pictures/scaling.png)` rather than `![benchmark chart](/assets/media/pictures/scaling.png)`.
+Use empty alt text (`![]`) for purely decorative images.
 13. Expand an acronym on first use with the acronym in parentheses.
 
 ## Step 3: Write about yourself
 
 Blog posts on [valkey.io](http://valkey.io/) need to have at least one author.
 This needs to be a person: it does not need to be birth name or even a traditional name, but it can’t be a collective (e.g. “The Good Code Team” would be unacceptable).
-Ideally, this you write under a transparent and accountable name where you can be identified in the Valkey community.
+Ideally you write under a transparent and accountable name, one the Valkey community can connect to your other contributions.
 
 Each author needs to have a biography.
 The bio should be 1-2 paragraphs in length and should tell the reader who you are.
 Additionally, use the space to link yourself to the community: what makes you a person the reader should read and spend time on.
 If you already have a bio from a previous post, you don’t need to do a new one.
+If you identify yourself as an employee of a company, make sure your employer is okay with you doing so.
 
 It’s optional, but blog posts are even better when you have a bio *and* a photo.
 This personalizes the content further and conveys that you’re a real person.

--- a/CONTRIBUTING-BLOG-POST.md
+++ b/CONTRIBUTING-BLOG-POST.md
@@ -25,6 +25,9 @@ However, if you don’t get the feedback from the maintainers you run the risk o
 
 Write your blog post in markdown.
 Generally, you’ll be better off sticking to headings, links, paragraphs and code blocks (there is no prohibition of using other markdown features though).
+
+### What to write about
+
 A few writing tips:
 
 1. Blog posts should be consumable in one sitting.
@@ -44,6 +47,38 @@ You can even just invite readers to consume related content.
 7. Speak for yourself.
 Blog posts are attributed to a person, not the project, so feel free to have opinions and write in the first (I) or second (you) grammatical person.
 Unless you have specific authority (and you probably don’t!), avoid speaking for groups of people.
+
+### How to write it
+
+Reviewers use these as the basis for suggestions, so knowing them up front saves a round trip.
+This document follows them, so read its source as an example.
+
+1. Put one sentence per line in the markdown source.
+Markdown joins the lines back into a paragraph, so nothing changes about how the post renders.
+GitHub anchors suggestions to lines, so a reviewer can rewrite one sentence instead of rewriting the paragraph.
+2. Cut weasel words.
+“Significantly faster” and “various improvements” imply a claim without making one.
+Replace them with the number, name, or link they stood in for, or delete them.
+    1. The same goes for padding: “basically”, “quite”, “simply”, “very”, “actually”, “of course”.
+    2. You can hedge when there is uncertainty, but say where it comes from: “we have not measured this on ARM”, not “this should probably be fine”.
+3. Make every claim checkable.
+Give numbers with their units and the setup that produced them, link behavior claims to a pull request or the docs, and name the version a behavior applies to.
+4. Use default or stock Valkey when possible.
+Run the latest version of Valkey with the default configuration.
+If you aren't running the latest version or the default configuration, discuss why.
+5. Credit contributors by name when you describe their work.
+If applicable, include a link to their github or blog profile.
+6. Prefer active voice and one idea per sentence.
+“The replica requests a full sync” beats “a full sync is requested by the replica”.
+7. Write descriptive headings, not clever ones.
+Make sure each header is clear to the end user.
+Feel free to make creative jokes and puns, but not at the expense of reading for our global audience.
+8. Use inclusive terminology in prose, diagrams, and code: primary and replica, allowlist and denylist.
+9. Use uppercase backticks for commands like `SET` and `XADD`.
+10. Use lowercase backticks when describing executable names, configs, and info fields like `valkey-server` and `cluster-node-timeout`.
+11. Tag code blocks with a language so that they render correctly.
+12. Give images alt text describing what they show to make them more inclusive.
+13. Expand an acronym on first use with the acronym in parentheses.
 
 ## Step 3: Write about yourself
 

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,9 @@ taxonomies = [
     { name = "blog_type", render = false },
 ]
 
+# Reference files that live alongside content but should not be published
+ignored_content = ["*.example"]
+
 [markdown.highlighting]
 theme = "github-dark-default"
 

--- a/content/blog/example-post.md.example
+++ b/content/blog/example-post.md.example
@@ -1,22 +1,21 @@
 +++
-# This file is a reference example for CONTRIBUTING-BLOG-POST.md, not a real post.
+# Reference example for CONTRIBUTING-BLOG-POST.md, not a real post.
 # The `.example` suffix matches `ignored_content` in config.toml, so Zola never publishes it.
-# Copy it to `content/blog/YYYY-MM-DD-your-slug.md` and delete these notes to start a post.
-# The frontmatter must begin at the very first character of the file, as it does here.
+# To start a post, copy this to `content/blog/YYYY-MM-DD-your-slug.md` and delete these notes.
+# Frontmatter must begin at the very first character of the file, as it does here.
 #
-# The topic, benchmark numbers, pull request link, and contributor credit are all invented
-# placeholders. Everything else demonstrates a rule from the guide: one sentence per line,
-# checkable claims, backtick casing, alt text, tagged code blocks, acronym expansion,
-# inclusive terminology, and a call to action.
+# Two deliberate deviations, so you don't copy them by mistake:
+# this is ~300 words rather than the 500-1,200 a real post should aim for, and it credits
+# no contributor because it describes no one's work. Credit people by name when it does.
 #
 # Descriptive, not clever. This is the page title and the blog listing entry.
-title = "How Valkey splits request handling across I/O threads"
-# The date you started writing is fine; maintainers set the real publish date.
+title = "When a Valkey hash stops being a listpack"
+# The day you started writing is fine; maintainers set the real publish date.
 # The time is irrelevant to publishing, so '01:01:01' is the usual placeholder.
 date = 2026-01-15 01:01:01
 # Two short sentences, written as a hook rather than a copy of your first paragraph.
-description = "Valkey can hand socket reads and writes to dedicated threads instead of doing everything on one thread. Here is how the split works and what to measure before you change it."
-# One entry per author, matching a file in content/authors/.
+description = "A Valkey hash changes its encoding once it passes 512 fields, and it never changes back. Here is how to watch it happen and what the switch costs you."
+# One entry per author, each matching a file in content/authors/.
 authors = ["madolson"]
 
 [taxonomies]
@@ -28,68 +27,48 @@ featured = false
 featured_image = "/assets/media/featured/random-01.webp"
 +++
 
-Valkey runs commands on a single thread.
-That design keeps the data structures free of locks, and it is the reason a command like [`INCR`](/commands/incr/) is atomic without any coordination between clients.
-It also means that one thread has to do everything else too: reading bytes off sockets, parsing them, running the command, and writing the reply back.
+Valkey stores a small hash as a listpack, a flat array of field-value pairs.
+Once the hash grows past a threshold, Valkey converts it to a hash table.
+The conversion runs one way only: deleting fields afterward does not convert it back.
 
-On a machine with many cores, that single thread becomes the limit long before the cores do.
-I/O threading changes the split.
-This post covers what moves off the main thread, how to turn it on, and what to measure before and after.
+## Watching the conversion
 
-## What the main thread does
-
-Every client connection is a socket.
-For each event loop iteration, the server waits for sockets to become readable, reads the pending bytes, parses each request, executes it, and queues the reply.
-
-Reading and writing are the parts that scale with connection count rather than with the work each command does.
-A `GET` against a small string costs the same regardless of how many clients are connected, but the socket handling in front of it does not.
-
-## How the work is split
-
-With I/O threads enabled, the main thread stops doing socket reads and writes itself and hands them to a pool of worker threads.
-
-![The main thread waits on epoll, sends read jobs to two I/O threads, prefetches command keys, processes commands, then sends write and free jobs back to the I/O threads](/assets/media/pictures/io_threads.png)
-
-The main thread still runs every command, in order, by itself.
-The I/O threads only move bytes and free objects.
-Command execution stays single threaded, so the atomicity guarantees do not change.
-
-## Turning it on
-
-Set `io-threads` at startup.
-The value includes the main thread, so `io-threads 4` starts three I/O threads alongside it:
+`hash-max-listpack-entries` sets the threshold and defaults to 512.
+`OBJECT ENCODING` reports the encoding a key uses right now:
 
 ```bash
-valkey-server --io-threads 4
+valkey-cli DEL h
+valkey-cli HSET h field1 value1
+valkey-cli OBJECT ENCODING h    # listpack
 ```
 
-You can confirm the setting took effect with [`CONFIG GET`](/commands/config-get/):
+Push the hash past 512 fields and the encoding changes:
 
 ```bash
-valkey-cli CONFIG GET io-threads
+for i in $(seq 1 513); do echo "HSET h f$i v$i"; done | valkey-cli --pipe
+valkey-cli OBJECT ENCODING h    # hashtable
 ```
 
-Start at 4 and increase it while watching throughput.
-Past the point where socket handling stops being the bottleneck, more threads add scheduling overhead without adding requests per second (RPS).
+A field value longer than `hash-max-listpack-value`, 64 bytes by default, also forces the conversion.
 
-## What to measure
+A hash table costs more memory because each field-value pair gets its own entry, and those entries hang off a bucket array:
 
-Measure before you change anything, and measure requests per second alongside latency.
-Throughput that climbs while p99 latency climbs faster is not usually a win.
+![A four slot bucket array, with slot 2 pointing to an entry holding a key, a value, and a next pointer](/assets/media/pictures/dictionary_bucket_and_entry_overview.png)
 
-A checkable result names the setup that produced it, like this (the figures here are invented for the example):
-on a 16 core instance running `valkey-benchmark` with 512 connections against Valkey 9.0 with an otherwise default configuration, moving from `io-threads 1` to `io-threads 4` took throughput from 250,000 to 610,000 RPS.
-Compare that to "I/O threads made it significantly faster", which asserts a result without giving the reader anything to check.
+## What the switch costs
 
-Two things that will not show up in a benchmark but will show up in production:
+I compared two hashes holding the same 512 field-value pairs.
+One stayed a listpack.
+The other I converted by adding a 513th field and deleting it again.
+Both ran on Valkey 9.1.1, built from the release tag with a default configuration:
 
-1. Each I/O thread has its own stack and buffers, so memory use rises with the thread count.
-2. A primary and its replicas do not need the same setting.
-Replicas handle a different traffic shape, so tune them separately.
+- listpack: 6,176 bytes
+- hash table: 16,952 bytes
+
+That is 2.7 times the memory for identical contents.
+`MEMORY USAGE` reports one object, not the resident set size (RSS) of the whole process, so treat it as a per-key comparison rather than a capacity estimate.
 
 ## Next steps
 
-Try it on a workload you already have numbers for, and compare against your existing baseline rather than against the figures in this post.
-If you find a case where more threads make things worse, [open an issue](https://github.com/valkey-io/valkey/issues) with your configuration and workload.
-
-Thanks to [Contributor Name](https://github.com/octocat) for the prefetching work in [pull request #1234](https://github.com/valkey-io/valkey/pull/1234) that made much of this possible.
+Run `OBJECT ENCODING` against the hashes in your own keyspace before you raise the threshold.
+Reproduce the numbers above with the commands in this post, and if your results disagree, [open an issue](https://github.com/valkey-io/valkey/issues) with your version and configuration.

--- a/content/blog/example-post.md.example
+++ b/content/blog/example-post.md.example
@@ -51,9 +51,11 @@ valkey-cli OBJECT ENCODING h    # hashtable
 
 A field value longer than `hash-max-listpack-value`, 64 bytes by default, also forces the conversion.
 
-A hash table costs more memory because each field-value pair gets its own entry, and those entries hang off a bucket array:
+A hash table costs more memory because of what it has to allocate.
+It keeps an array of buckets, and each bucket points to an entry holding a key, a value, and a `next` pointer to the following entry in that bucket.
+A listpack stores the same pairs back to back in a single allocation, with no bucket array and no pointers.
 
-![A four slot bucket array, with slot 2 pointing to an entry holding a key, a value, and a next pointer](/assets/media/pictures/dictionary_bucket_and_entry_overview.png)
+![Bucket array and entry layout of a hash table](/assets/media/pictures/dictionary_bucket_and_entry_overview.png)
 
 ## What the switch costs
 

--- a/content/blog/example-post.md.example
+++ b/content/blog/example-post.md.example
@@ -1,0 +1,95 @@
++++
+# This file is a reference example for CONTRIBUTING-BLOG-POST.md, not a real post.
+# The `.example` suffix matches `ignored_content` in config.toml, so Zola never publishes it.
+# Copy it to `content/blog/YYYY-MM-DD-your-slug.md` and delete these notes to start a post.
+# The frontmatter must begin at the very first character of the file, as it does here.
+#
+# The topic, benchmark numbers, pull request link, and contributor credit are all invented
+# placeholders. Everything else demonstrates a rule from the guide: one sentence per line,
+# checkable claims, backtick casing, alt text, tagged code blocks, acronym expansion,
+# inclusive terminology, and a call to action.
+#
+# Descriptive, not clever. This is the page title and the blog listing entry.
+title = "How Valkey splits request handling across I/O threads"
+# The date you started writing is fine; maintainers set the real publish date.
+# The time is irrelevant to publishing, so '01:01:01' is the usual placeholder.
+date = 2026-01-15 01:01:01
+# Two short sentences, written as a hook rather than a copy of your first paragraph.
+description = "Valkey can hand socket reads and writes to dedicated threads instead of doing everything on one thread. Here is how the split works and what to measure before you change it."
+# One entry per author, matching a file in content/authors/.
+authors = ["madolson"]
+
+[taxonomies]
+# One of: Technical Deep Dive, Announcements, Community Highlight, How-to, Events
+blog_type = ["Technical Deep Dive"]
+
+[extra]
+featured = false
+featured_image = "/assets/media/featured/random-01.webp"
++++
+
+Valkey runs commands on a single thread.
+That design keeps the data structures free of locks, and it is the reason a command like [`INCR`](/commands/incr/) is atomic without any coordination between clients.
+It also means that one thread has to do everything else too: reading bytes off sockets, parsing them, running the command, and writing the reply back.
+
+On a machine with many cores, that single thread becomes the limit long before the cores do.
+I/O threading changes the split.
+This post covers what moves off the main thread, how to turn it on, and what to measure before and after.
+
+## What the main thread does
+
+Every client connection is a socket.
+For each event loop iteration, the server waits for sockets to become readable, reads the pending bytes, parses each request, executes it, and queues the reply.
+
+Reading and writing are the parts that scale with connection count rather than with the work each command does.
+A `GET` against a small string costs the same regardless of how many clients are connected, but the socket handling in front of it does not.
+
+## How the work is split
+
+With I/O threads enabled, the main thread stops doing socket reads and writes itself and hands them to a pool of worker threads.
+
+![The main thread waits on epoll, sends read jobs to two I/O threads, prefetches command keys, processes commands, then sends write and free jobs back to the I/O threads](/assets/media/pictures/io_threads.png)
+
+The main thread still runs every command, in order, by itself.
+The I/O threads only move bytes and free objects.
+Command execution stays single threaded, so the atomicity guarantees do not change.
+
+## Turning it on
+
+Set `io-threads` at startup.
+The value includes the main thread, so `io-threads 4` starts three I/O threads alongside it:
+
+```bash
+valkey-server --io-threads 4
+```
+
+You can confirm the setting took effect with [`CONFIG GET`](/commands/config-get/):
+
+```bash
+valkey-cli CONFIG GET io-threads
+```
+
+Start at 4 and increase it while watching throughput.
+Past the point where socket handling stops being the bottleneck, more threads add scheduling overhead without adding requests per second (RPS).
+
+## What to measure
+
+Measure before you change anything, and measure requests per second alongside latency.
+Throughput that climbs while p99 latency climbs faster is not usually a win.
+
+A checkable result names the setup that produced it, like this (the figures here are invented for the example):
+on a 16 core instance running `valkey-benchmark` with 512 connections against Valkey 9.0 with an otherwise default configuration, moving from `io-threads 1` to `io-threads 4` took throughput from 250,000 to 610,000 RPS.
+Compare that to "I/O threads made it significantly faster", which asserts a result without giving the reader anything to check.
+
+Two things that will not show up in a benchmark but will show up in production:
+
+1. Each I/O thread has its own stack and buffers, so memory use rises with the thread count.
+2. A primary and its replicas do not need the same setting.
+Replicas handle a different traffic shape, so tune them separately.
+
+## Next steps
+
+Try it on a workload you already have numbers for, and compare against your existing baseline rather than against the figures in this post.
+If you find a case where more threads make things worse, [open an issue](https://github.com/valkey-io/valkey/issues) with your configuration and workload.
+
+Thanks to [Contributor Name](https://github.com/octocat) for the prefetching work in [pull request #1234](https://github.com/valkey-io/valkey/pull/1234) that made much of this possible.


### PR DESCRIPTION
Adds a `How to write it` subsection to Step 2 of the blog contributing guide.
It captures the style guidance reviewers already apply, so contributors can see it before the first review round rather than during it.

The one rule with a functional reason behind it is one sentence per line.
Markdown joins the lines back into a paragraph, so nothing changes about how a post renders.
It changes review: GitHub anchors suggestions to lines, so a reviewer can rewrite a single sentence instead of restating the whole paragraph, and two reviewers touching different sentences don't conflict.

The rest covers weasel words, checkable claims, benchmarking on stock Valkey, crediting contributors, active voice, headings, inclusive terminology, and formatting conventions.
The section follows its own guidance, so its source doubles as an example.
