### PR TITLE
Add Valkey GLIDE PHP and Ruby clients to recommended clients list

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -36,7 +36,7 @@ button_url = "/commands"
 [[extra.documentation_cards]]
 title = "Clients"
 description = "Official Valkey client libraries include support for:"
-features = ["Python", "Java", "Go", "Node.js", "PHP", "C#"]
+features = ["Python", "Java", "Go", "Node.js", "PHP", "C#", "Ruby"]
 button_text = "Learn More"
 button_url = "/clients"
 

--- a/content/clients/_index.md
+++ b/content/clients/_index.md
@@ -12,10 +12,12 @@ recommended_clients_paths = [
     "/java/redisson.json",
     "/go/valkey-GLIDE.json",
     "/go/valkey-go.json",
+    "/php/valkey-GLIDE.json",
     "/php/phpredis.json",
     "/php/predis.json",
     "/swift/valkey-swift.json",
-    "/csharp/valkey-GLIDE.json"
+    "/csharp/valkey-GLIDE.json",
+    "/ruby/valkey-GLIDE.json"
     ] 
 
 client_fields =[


### PR DESCRIPTION
### Description

Adds the Valkey GLIDE PHP and Valkey GLIDE Ruby clients to the recommended clients list on `/clients/`.

**Note:** Supersedes #557, which adds the PHP entry only. Happy to drop the PHP line here instead if @adrianluna would rather land that one.