### PR TITLE
Unfurl blog posts with their own image, not the logo

### DIFF
--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -6,7 +6,7 @@
     <meta name="MSSmartTagsPreventParsing" content="true" />
     <meta name="Copyright" content="" />
     <meta name="keywords" content="open-source, valkey" />
-    <meta property="og:image" content="/img/valkey-logo-og.png" />
+    <meta property="og:image" content="{{ config.base_url }}{% if page and page.extra and page.extra.featured_image %}{{ page.extra.featured_image }}{% else %}/img/valkey-logo-og.png{% endif %}" />
     {% if page and page.extra and page.extra.custom_meta%}
     {{ page.extra.custom_meta | safe }}
     {% endif %}


### PR DESCRIPTION
Every blog post unfurls with the Valkey logo. `og:image` is hardcoded in `templates/includes/head.html:9` and ignores the `featured_image` the page already renders as its hero. Now uses `featured_image` when set, logo otherwise, and makes the URL absolute since a relative `og:image` is out of spec.

Zola autoescapes the interpolated path, so the tag renders `&#x2F;` instead of `/`. Scrapers decode it, same as the `<img src>` on every existing post.

`zola build`: all 63 blog pages point at an image file that exists. Posts with no `featured_image`, sections, and the homepage still get the logo.

*This was generated by AI but verified, with love, by a human.*
