### PR TITLE
Add /events/valkeyconf alias for the ValkeyConf event page

### DIFF
--- a/content/events/valkeyconf-2026.md
+++ b/content/events/valkeyconf-2026.md
@@ -1,6 +1,7 @@
 +++
 title = "ValkeyConf 2026"
 date = 2026-10-05 01:01:01
+aliases = ["/events/valkeyconf"]
 
 [extra]
 event_type = "first-party"


### PR DESCRIPTION
Emily asked for a short, project-owned URL for ValkeyConf so we don't have to hand out the full Linux Foundation link in slides and social posts.

The event page already exists and already redirects, so this just adds `aliases = ["/events/valkeyconf"]` to `content/events/valkeyconf-2026.md`. `valkey.io/events/valkeyconf` now lands on https://events.linuxfoundation.org/valkeyconf/ by way of the existing page.

Note that is two hops, both instant: the alias stub redirects to `/events/valkeyconf-2026/`, which meta-refreshes to the LF site. Avoiding it would mean renaming the existing published URL, which isn't worth it. A real 301 isn't possible either, since GitHub Pages serves `valkey.io` directly with no redirect config.

Tested with `zola build`: the alias stub is generated and ValkeyConf still appears exactly once on the events calendar. (The build also hits a pre-existing `build-clients` failure unrelated to this change; it reproduces on a clean `main`.)

This was generated by AI but verified, with love, by a human.