### PR TITLE
Rework the homepage and download pages around release versions

### DIFF
--- a/_data/perf.toml
+++ b/_data/perf.toml
@@ -2,15 +2,17 @@
 # Both `title` and `description` can contain markdown for styles, but not links.
 # [[dashboards]]
 # title = "GETs/SETs on `9.0.0`"
+# button_text = "Explore"
 # description = "Performance dashboard of GETs and SETs on the Valkey 9.0.0 release. Updated on Oct 21, 2025."
 # link = "https://perf-dashboard.valkey.io/public-dashboards/3e45bf8ded3043edaa941331cd1a94e2"
 
 # Order in this file indicates rendering order.
 
 [[dashboards]]
-title = "Valkey Performance Dashboards"
-description = "Valkey Performance Dashboards provide a consolidated view of throughput trends across versions, helping teams validate improvements and identify regressions."
+title = "Performance Dashboards"
+description = "Throughput trends across every Valkey version."
 link = "/performance/"
+button_text = "Explore"
 
 # Performance dashboard sections for /performance page
 # Order in this file indicates rendering order.

--- a/_data/perf.toml
+++ b/_data/perf.toml
@@ -1,19 +1,3 @@
-# Example of a homepage performance card.
-# Both `title` and `description` can contain markdown for styles, but not links.
-# [[dashboards]]
-# title = "GETs/SETs on `9.0.0`"
-# button_text = "Explore"
-# description = "Performance dashboard of GETs and SETs on the Valkey 9.0.0 release. Updated on Oct 21, 2025."
-# link = "https://perf-dashboard.valkey.io/public-dashboards/3e45bf8ded3043edaa941331cd1a94e2"
-
-# Order in this file indicates rendering order.
-
-[[dashboards]]
-title = "Performance Dashboards"
-description = "Throughput trends across every Valkey version."
-link = "/performance/"
-button_text = "Explore"
-
 # Performance dashboard sections for /performance page
 # Order in this file indicates rendering order.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -6,6 +6,9 @@ repos_heading= "Featured repositories"
 github_org= "https://github.com/valkey-io"
 github_org_text= "All repos in the Valkey GitHub organization"
 
+# Number of blog posts shown in the "Latest Blog Posts" panel.
+latest_blog_posts= 3
+
 headline= "Valkey: an open source, in-memory data store"
 long_description= ""
 
@@ -14,12 +17,6 @@ headings = ["FAST. RELIABLE.", "OPEN SOURCE, FOREVER."]
 subtitle = "Valkey is an open source (BSD) high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database. The project is backed by the Linux Foundation, ensuring it will remain open source forever."
 button_text = "GET STARTED"
 button_url = "/topics/quickstart"
-
-[[extra.documentation_cards]]
-title = "Install"
-description = "Step-by-step instructions on how to install and configure Valkey for first-time users."
-button_text = "See Installation Guide"
-button_url = "/topics/installation"
 
 [[extra.documentation_cards]]
 title = "Usage guide"
@@ -35,8 +32,7 @@ button_url = "/commands"
 
 [[extra.documentation_cards]]
 title = "Clients"
-description = "Official Valkey client libraries include support for:"
-features = ["Python", "Java", "Go", "Node.js", "PHP", "C#", "Ruby"]
+description = "Official Valkey client libraries for Python, Java, Go, Node.js, PHP, C#, Ruby, and more."
 button_text = "Learn More"
 button_url = "/clients"
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -7,7 +7,7 @@ github_org= "https://github.com/valkey-io"
 github_org_text= "All repos in the Valkey GitHub organization"
 
 # Number of blog posts shown in the "Latest Blog Posts" panel.
-latest_blog_posts= 3
+latest_blog_posts= 4
 
 headline= "Valkey: an open source, in-memory data store"
 long_description= ""

--- a/content/_index.md
+++ b/content/_index.md
@@ -36,6 +36,12 @@ description = "Official Valkey client libraries for Python, Java, Go, Node.js, P
 button_text = "Learn More"
 button_url = "/clients"
 
+[[extra.documentation_cards]]
+title = "Performance"
+description = "Throughput trends across every Valkey version."
+button_text = "Explore"
+button_url = "/performance/"
+
 [[extra.download_ctas]]
 text= "Get Valkey"
 url=  "/download/"
@@ -48,7 +54,7 @@ title= "Read the docs"
 
 +++
 
-## Documentation
+## Learn more
 
 Valkey can run as either a **standalone** daemon or in a **cluster**, with options for **replication** and **high availability**. Valkey natively supports a rich collection of datatypes, including **strings**, **numbers**, **hashes**, **lists**, **sets**, **sorted sets**, **bitmaps**, **hyperloglogs** and more.
 You can operate on data structures in-place with an expressive collection of commands.

--- a/content/_index.md
+++ b/content/_index.md
@@ -38,7 +38,7 @@ button_url = "/clients"
 
 [[extra.documentation_cards]]
 title = "Performance"
-description = "Throughput trends across every Valkey version."
+description = "Deep dive into Valkey performance numbers across versions."
 button_text = "Explore"
 button_url = "/performance/"
 

--- a/content/download/index.md
+++ b/content/download/index.md
@@ -2,3 +2,7 @@
 template = "download.html"
 title = "Download"
 +++
+
+For installation instructions, supported package managers, and how to configure Valkey, see the
+[installation](/topics/installation) page. Every release ever published, including security fixes
+for older versions, is on the [releases](/download/releases/) page.

--- a/content/download/versions/7-2.md
+++ b/content/download/versions/7-2.md
@@ -1,0 +1,8 @@
++++
+title = "Valkey 7.2"
+path = "download/7.2"
+[extra]
+version = "7.2"
++++
+
+- The first stable Valkey release, matching the protocol, API, return values, and data file formats of Redis 7.2.4.

--- a/content/download/versions/8-0.md
+++ b/content/download/versions/8-0.md
@@ -1,0 +1,14 @@
++++
+title = "Valkey 8.0"
+path = "download/8.0"
+[extra]
+version = "8.0"
+blog_url = "/blog/valkey-8-ga/"
+blog_text = "What's new in Valkey 8.0"
++++
+
+- **[Asynchronous I/O threading](/blog/unlock-one-million-rps/)** lifts throughput from 380K to over 1.2 million queries per second.
+- **Dual-channel replication** sends the RDB and the replica backlog at once, easing memory pressure on the primary.
+- **Reliable slot migration**: `CLUSTER SETSLOT` replicates synchronously and survives failover.
+- **Automatic failover for empty shards**, so a scale-out is highly available from the first moment.
+- No backwards-incompatible command changes, so existing tools work untouched.

--- a/content/download/versions/8-1.md
+++ b/content/download/versions/8-1.md
@@ -1,0 +1,14 @@
++++
+title = "Valkey 8.1"
+path = "download/8.1"
+[extra]
+version = "8.1"
+blog_url = "/blog/valkey-8-1-0-ga/"
+blog_text = "What's new in Valkey 8.1"
++++
+
+- **[A rewritten hashtable](/blog/new-hash-table/)** cuts roughly 20 bytes per key-value pair and adds about 10% throughput.
+- **3.5x faster keyspace iteration**, shortening full syncs and [`KEYS`](/commands/keys/).
+- **TLS negotiation offloaded to I/O threads**, accepting new encrypted connections around 300% faster.
+- **[`COMMANDLOG`](/commands/commandlog/)** records large requests and replies, not just slow commands.
+- Structured `logfmt` logs, ISO 8601 timestamps, and [`SET IFEQ`](/commands/set/) for conditional updates.

--- a/content/download/versions/9-0.md
+++ b/content/download/versions/9-0.md
@@ -1,0 +1,14 @@
++++
+title = "Valkey 9.0"
+path = "download/9.0"
+[extra]
+version = "9.0"
+blog_url = "/blog/introducing-valkey-9/"
+blog_text = "What's new in Valkey 9.0"
++++
+
+- **[Atomic slot migration](/blog/atomic-slot-migration/)** streams whole slots instead of key-by-key, so resharding no longer stalls on hot keys.
+- **[Hash field expiration](/blog/hash-fields-expiration/)** puts a TTL on individual hash fields with [`HEXPIRE`](/commands/hexpire/).
+- **[Numbered databases in cluster mode](/blog/numbered-databases/)**, so [`SELECT`](/commands/select/) is no longer restricted to database 0.
+- **[1 billion requests per second](/blog/1-billion-rps/)** across clusters scaling to 2,000 nodes.
+- Zero-copy responses, Multipath TCP, SIMD [`BITCOUNT`](/commands/bitcount/), and the new [`DELIFEQ`](/commands/delifeq/) command.

--- a/content/download/versions/9-1.md
+++ b/content/download/versions/9-1.md
@@ -1,0 +1,14 @@
++++
+title = "Valkey 9.1"
+path = "download/9.1"
+[extra]
+version = "9.1"
+blog_url = "/blog/valkey-9-1-delivers-improvements-in-security-performance-and-more/"
+blog_text = "What's new in Valkey 9.1"
++++
+
+- **[2.1 million requests per second](/performance/)** on a single server, on the back of a redesigned I/O threading model.
+- **Per-database [ACLs](/topics/acl/)** scope a user's permissions to specific numbered databases, via `db=` on [`ACL SETUSER`](/commands/acl-setuser/).
+- **JSON server logs** via `log-format json` in [`valkey.conf`](/topics/valkey.conf/), parseable without custom patterns.
+- **Lua is now a module**, so you can drop the [scripting engine](/topics/eval-intro/) entirely if you don't need it.
+- Up to **20% less memory** for small strings, plus the new [`HGETDEL`](/commands/hgetdel/), [`MSETEX`](/commands/msetex/), and [`CLUSTERSCAN`](/commands/clusterscan/) commands.

--- a/content/download/versions/_index.md
+++ b/content/download/versions/_index.md
@@ -1,0 +1,7 @@
++++
+# Holds the /download/<line>/ pages. Each page overrides its own path, so this
+# section is never rendered itself.
+render = false
+page_template = "release-line.html"
+sort_by = "title"
++++

--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -1761,7 +1761,9 @@ html.banner-hidden .banner {
 // Documentation Section Styles
 .documentation-section {
   padding: 4rem 2rem;
-  background: #6983FF;
+  // Continues the .whats-new-section gradient, finishing on the #6983ff that
+  // .homepage-participants-section starts from.
+  background: linear-gradient(rgb(81, 85, 193), #6983FF);
   position: relative;
   text-align: center;
   color: white;
@@ -1861,7 +1863,9 @@ html.banner-hidden .banner {
 // What's New Section Styles
 .whats-new-section {
   padding-bottom: 4rem;
-  background-image: linear-gradient(rgb(48, 23, 110), rgb(105, 131, 255));
+  // Stops short of the full #6983ff so the section doesn't end glaring bright.
+  // .documentation-section picks the gradient up from here.
+  background-image: linear-gradient(rgb(48, 23, 110), rgb(81, 85, 193));
 
   @include respond-min(768px) {
     padding: 0 0 8rem;
@@ -1914,6 +1918,155 @@ html.banner-hidden .banner {
     hr {
       margin: 2rem 0;
     }
+  }
+}
+
+.release-headline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 1rem;
+  margin: 0 0 1.5rem;
+  font-size: 2rem;
+  font-weight: 700;
+
+  small {
+    font-size: 1.3rem;
+    font-weight: 400;
+    color: #4a5568;
+  }
+}
+
+.release-highlights {
+  ul {
+    margin: 0 0 1rem;
+    padding-left: 18px;
+  }
+
+  li {
+    margin-bottom: .6rem;
+    font-size: 1.5rem;
+    line-height: 1.4;
+  }
+}
+
+.release-table {
+  width: 100%;
+  margin: 0 0 3rem;
+  border-collapse: collapse;
+
+  border: 1px solid #ddd;
+
+  th,
+  td {
+    padding: 1rem 1.6rem;
+    text-align: left;
+    border-bottom: 1px solid #e0e0e0;
+  }
+
+  th {
+    background: #f4f4f4;
+    color: #555;
+    font-weight: 700;
+  }
+
+  tbody tr:nth-child(even) {
+    background: #f9f9f9;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: 0;
+  }
+
+  td:first-child {
+    font-weight: 700;
+  }
+}
+
+.copy-code {
+  display: flex;
+  align-items: stretch;
+  margin: 0 0 2rem;
+  border: 1px solid #eaeaea;
+  border-radius: 8px;
+  background: #f5f7f7;
+  overflow: hidden;
+
+  pre {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    padding: 1.2rem 1.6rem;
+    background: none;
+    font-size: 1.4rem;
+  }
+
+  code {
+    white-space: pre;
+  }
+}
+
+.copy-code-button {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  border: 0;
+  border-left: 1px solid #eaeaea;
+  padding: 0;
+  background: none;
+  color: #6b7280;
+  cursor: pointer;
+
+  &:hover {
+    background: $white;
+    color: #2054b2;
+  }
+
+  // Swap the clipboard glyph for a checkmark while the copy is fresh.
+  .copy-code-icon-done {
+    display: none;
+  }
+
+  &.copied {
+    color: #1a7f37;
+
+    .copy-code-icon-copy {
+      display: none;
+    }
+
+    .copy-code-icon-done {
+      display: block;
+    }
+  }
+}
+
+.copy-code-icon {
+  width: 1.6rem;
+  height: 1.6rem;
+}
+
+// The global `hr` has no margin, which reads as cramped between sections.
+.release-rule {
+  margin: 3rem 0 0;
+}
+
+.release-links {
+  margin: 0;
+
+  li {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: .6rem;
+    font-size: 1.5rem;
+  }
+
+  small {
+    font-size: 1.3rem;
+    color: #4a5568;
   }
 }
 
@@ -2135,18 +2288,36 @@ blockquote {
   }
 }
 
-// Homepage Blog Cards with Featured Images
-.homepage-performance-section,
+// Homepage blog cards: stacked vertically, each laid out horizontally with the
+// featured image beside the text.
 .homepage-blog-section {
   display: flex;
   flex-direction: column;
   gap: 2rem;
-}
-.homepage-performance-section {
   margin-bottom: 3rem;
+
+  @include respond-min(768px) {
+    .homepage-blog-card {
+      flex-direction: row;
+      min-height: 165px;
+    }
+
+    .homepage-blog-card-image,
+    .homepage-blog-card-image-placeholder {
+      flex: 0 0 230px;
+      width: 230px;
+      height: auto;
+      align-self: stretch;
+      border-radius: 10px 0 0 10px;
+    }
+
+    .homepage-blog-card-content {
+      padding: 1.6rem 2rem;
+      justify-content: center;
+    }
+  }
 }
 
-.homepage-performance-card,
 .homepage-blog-card {
   background: #fff;
   border-radius: 10px;
@@ -2155,6 +2326,16 @@ blockquote {
   transition: box-shadow 0.2s ease;
   display: flex;
   flex-direction: column;
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+
+    .homepage-blog-card-title {
+      color: #667eea;
+    }
+  }
 }
 
 .homepage-blog-card-image {
@@ -2173,7 +2354,6 @@ blockquote {
   border-top-right-radius: 10px;
 }
 
-.homepage-performance-card-content,
 .homepage-blog-card-content {
   padding: 1.5rem;
   flex: 1;
@@ -2181,29 +2361,16 @@ blockquote {
   flex-direction: column;
 }
 
-.homepage-performance-card h4 p {
-  margin: none;
-}
-.homepage-performance-card h4,
 .homepage-blog-card-title {
   margin: 0 0 1rem 0;
   font-size: 1.6rem;
   line-height: 1.3;
   font-weight: 700;
-
-  a {
-    color: #002a3a;
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  a:hover {
-    color: #667eea;
-  }
+  color: #002a3a;
+  transition: color 0.2s ease;
 }
-.homepage-performance-card h4 + p,
 .homepage-blog-card-description {
-  margin: 0 0 1.5rem 0;
+  margin: 0;
   font-size: 1.4rem;
   line-height: 1.4;
   color: #4a5568;
@@ -2213,30 +2380,6 @@ blockquote {
   overflow: hidden;
   flex: 1;
 }
-.homepage-performance-card .view-dashboard,
-.homepage-blog-card-readmore {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1.2;
-  font-weight: 600;
-  font-size: 1.4rem;
-  padding: 0.8rem 1.6rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 50px;
-  color: #2d3748;
-  text-decoration: none;
-  align-self: flex-start;
-  transition: all 0.2s ease;
-  background: #fff;
-}
-.homepage-performance-card .view-dashboard:hover,
-.homepage-blog-card-readmore:hover {
-  background: #667eea;
-  color: #fff;
-  border-color: #667eea;
-}
-
 // Responsive adjustments for homepage blog cards
 @media (max-width: 768px) {
   .homepage-blog-card-image,

--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -2357,14 +2357,21 @@ blockquote {
   }
 }
 
+// `&:visited` is not redundant: the global `a:visited` is more specific than a
+// bare class, so without it the link falls back to the blue link colour.
 .homepage-blog-more {
+  &,
+  &:visited,
+  &:hover {
+    color: white;
+  }
+
   @include sans-serif;
   font-size: 1.4rem;
   font-weight: 700;
   text-transform: uppercase;
   text-decoration: none;
   white-space: nowrap;
-  color: rgba(255, 255, 255, 0.9);
 
   &:after {
     content: ' ›';
@@ -2372,7 +2379,7 @@ blockquote {
   }
 
   &:hover {
-    color: white;
+    text-decoration: underline;
   }
 }
 

--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -2290,44 +2290,22 @@ blockquote {
   }
 }
 
-// Homepage blog cards: stacked vertically, each laid out horizontally with the
-// featured image beside the text.
+// Homepage blog cards: text-only cards stacked vertically, matching the release
+// cards in the other column.
 .homepage-blog-section {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.5rem;
   margin-bottom: 3rem;
-
-  @include respond-min(768px) {
-    .homepage-blog-card {
-      flex-direction: row;
-      min-height: 165px;
-    }
-
-    .homepage-blog-card-image,
-    .homepage-blog-card-image-placeholder {
-      flex: 0 0 230px;
-      width: 230px;
-      height: auto;
-      align-self: stretch;
-      border-radius: 10px 0 0 10px;
-    }
-
-    .homepage-blog-card-content {
-      padding: 1.6rem 2rem;
-      justify-content: center;
-    }
-  }
 }
 
 .homepage-blog-card {
   background: #fff;
   border-radius: 10px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
+  padding: 2rem 2.5rem;
   transition: box-shadow 0.2s ease;
-  display: flex;
-  flex-direction: column;
+  display: block;
   color: inherit;
   text-decoration: none;
 
@@ -2340,61 +2318,45 @@ blockquote {
   }
 }
 
-.homepage-blog-card-image {
-  width: 100%;
-  height: 100px;
-  object-fit: cover;
-  border-top-left-radius: 10px;
-  border-top-right-radius: 10px;
-}
-
-.homepage-blog-card-image-placeholder {
-  width: 100%;
-  height: 100px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  border-top-left-radius: 10px;
-  border-top-right-radius: 10px;
-}
-
-.homepage-blog-card-content {
-  padding: 1.5rem;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
-
 .homepage-blog-card-title {
-  margin: 0 0 1rem 0;
-  font-size: 1.6rem;
+  margin: 0 0 0.5rem 0;
+  font-size: 1.8rem;
   line-height: 1.3;
   font-weight: 700;
   color: #002a3a;
   transition: color 0.2s ease;
 }
+
+.homepage-blog-card-meta {
+  margin: 0 0 1rem;
+  font-size: 1.3rem;
+  color: #4a5568;
+}
+
 .homepage-blog-card-description {
   margin: 0;
   font-size: 1.4rem;
   line-height: 1.4;
   color: #4a5568;
   display: -webkit-box;
-  -webkit-line-clamp: 5;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  flex: 1;
 }
+
+.homepage-blog-more {
+  align-self: flex-start;
+  color: white;
+}
+
 // Responsive adjustments for homepage blog cards
 @media (max-width: 768px) {
-  .homepage-blog-card-image,
-  .homepage-blog-card-image-placeholder {
-    height: 140px;
-  }
-
-  .homepage-blog-card-content {
-    padding: 1.2rem;
+  .homepage-blog-card {
+    padding: 1.5rem 1.8rem;
   }
 
   .homepage-blog-card-title {
-    font-size: 1.5rem;
+    font-size: 1.6rem;
   }
 
   .homepage-blog-card-description {

--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -2344,9 +2344,36 @@ blockquote {
   overflow: hidden;
 }
 
+// Sits on the heading row rather than under the cards, so the column ends on a
+// card edge instead of a stray link.
+.homepage-blog-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 2rem;
+
+  h3 {
+    width: auto;
+  }
+}
+
 .homepage-blog-more {
-  align-self: flex-start;
-  color: white;
+  @include sans-serif;
+  font-size: 1.3rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  text-decoration: none;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.8);
+
+  &:after {
+    content: ' ›';
+    font-size: 1.2em;
+  }
+
+  &:hover {
+    color: white;
+  }
 }
 
 // Responsive adjustments for homepage blog cards

--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -2349,8 +2349,8 @@ blockquote {
 .homepage-blog-heading {
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
-  gap: 2rem;
+  flex-wrap: wrap;
+  gap: 0 1.5rem;
 
   h3 {
     width: auto;
@@ -2359,12 +2359,12 @@ blockquote {
 
 .homepage-blog-more {
   @include sans-serif;
-  font-size: 1.3rem;
+  font-size: 1.4rem;
   font-weight: 700;
   text-transform: uppercase;
   text-decoration: none;
   white-space: nowrap;
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(255, 255, 255, 0.9);
 
   &:after {
     content: ' ›';

--- a/sass/_valkey.scss
+++ b/sass/_valkey.scss
@@ -1820,7 +1820,9 @@ html.banner-hidden .banner {
 .documentation-card {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  // Spaces title from description, and keeps the button off the description
+  // even when `margin-top: auto` has no slack left to push it down.
+  gap: 1.5rem;
   padding: 4rem;
   border-radius: 20px;
   color: white;

--- a/static/assets/js/copy-code.js
+++ b/static/assets/js/copy-code.js
@@ -1,0 +1,25 @@
+// Copy-to-clipboard for .copy-code blocks. Delegated, so blocks can appear
+// anywhere on the page without extra wiring.
+document.addEventListener('click', async function(event) {
+    const button = event.target.closest('.copy-code-button');
+    if (!button) {
+        return;
+    }
+
+    const block = button.closest('.copy-code');
+    const source = block && block.querySelector('code');
+    if (!source) {
+        return;
+    }
+
+    try {
+        await navigator.clipboard.writeText(source.textContent.trim());
+    } catch (error) {
+        return;
+    }
+
+    button.classList.add('copied');
+    setTimeout(function() {
+        button.classList.remove('copied');
+    }, 2000);
+});

--- a/templates/download.html
+++ b/templates/download.html
@@ -1,49 +1,51 @@
 {% extends "right-aside.html" %}
+{% import "macros/release.html" as release_macros %}
 
 {% block subhead_content%}
-<h1 class="page-title">Download Latest</h1>
+<h1 class="page-title">Download Valkey</h1>
 {% endblock subhead_content%}
 {% block main_content %}
 
+{# The newest stable release on each major.minor line, newest line first. #}
 {% set release_section = get_section(path="download/releases/_index.md") %}
-{% set releases = release_section.pages | reverse %}
-
-{% set_global active_releases = [] %}
-{% for release in releases %}
-    {% if release.extra.tag is not matching(".*-.*") %}
-        {% set_global active_releases = active_releases | concat(with=release) %}
+{% set_global release_lines = [] %}
+{% set_global seen_lines = [] %}
+{% for candidate in release_section.pages | sort(attribute="date") | reverse %}
+    {% if candidate.extra.tag is not matching(".*-.*") %}
+        {% set candidate_line = candidate.extra.tag | split(pat=".") | slice(end=2) | join(sep=".") %}
+        {% if candidate_line not in seen_lines %}
+            {% set_global seen_lines = seen_lines | concat(with=candidate_line) %}
+            {% set_global release_lines = release_lines | concat(with=candidate) %}
+        {% endif %}
     {% endif %}
 {% endfor %}
 
-{% set most_recent_release_page = active_releases | slice(end= 1) %}
-{% set release_date = most_recent_release_page[0].date %}
-{% set release = most_recent_release_page[0].extra %}
+{% set latest = release_lines | first %}
 
-{% set split_ver = release.tag | split(pat=".")%}
-{% set_global major = split_ver | nth(n= 0) %}
+{{ page.content | safe }}
 
-You can get the latest releases of Valkey from this page.<br />
-For installation instructions, supported package managers, and how to configure Valkey, see the <a href="/topics/installation">installation</a> page.<br />
-The <a href="./releases/">releases</a> page contains links to download all current and previous releases (including any security fixes for previous released versions).<br />
-<br />
+<h2>Latest release: Valkey {{ latest.extra.tag }}</h2>
+{{ release_macros::release_info(date=latest.date, release=latest.extra) }}
 
-<hr />
-
-
-<h3> Version {{major}}.x.x </h3>
-{% include "includes/release.html" %}
-
-<h2> Latest supported version of past releases</h2>
-
-{% for older_release in active_releases %}
-    {% set older_split_ver = older_release.extra.tag | split(pat=".")%}
-    {% set older_major = older_split_ver | nth(n= 0) %}
-    {% if older_major != major %}
-        {% set_global major = older_major %}
-        {% set release = older_release.extra %}
-        <h3> Version {{major}}.x.x </h3>
-        {% include "includes/release.html" %}
-    {% endif %}
-{% endfor %}
-
+<h2>Supported versions</h2>
+<p>Each version page has the release highlights, containers, and binaries for the newest release on that line.</p>
+<table class="release-table">
+    <thead>
+        <tr>
+            <th>Version</th>
+            <th>Latest release</th>
+            <th>Released</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for line_release in release_lines %}
+            {% set line = line_release.extra.tag | split(pat=".") | slice(end=2) | join(sep=".") %}
+            <tr>
+                <td><a href="/download/{{ line }}/">Valkey {{ line }}</a></td>
+                <td><a href="{{ line_release.permalink }}">{{ line_release.extra.tag }}</a></td>
+                <td>{{ line_release.date | date(format="%B %-d, %Y") }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
 {% endblock main_content %}

--- a/templates/download.html
+++ b/templates/download.html
@@ -40,8 +40,11 @@
     <tbody>
         {% for line_release in release_lines %}
             {% set line = line_release.extra.tag | split(pat=".") | slice(end=2) | join(sep=".") %}
+            {# get_page fails the build if a release ships without its line page. #}
+            {% set line_slug = line | replace(from=".", to="-") %}
+            {% set line_page = get_page(path="download/versions/" ~ line_slug ~ ".md") %}
             <tr>
-                <td><a href="/download/{{ line }}/">Valkey {{ line }}</a></td>
+                <td><a href="{{ line_page.permalink }}">Valkey {{ line }}</a></td>
                 <td><a href="{{ line_release.permalink }}">{{ line_release.extra.tag }}</a></td>
                 <td>{{ line_release.date | date(format="%B %-d, %Y") }}</td>
             </tr>

--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -63,6 +63,9 @@
     <!-- Carousel JS -->
     <script src="/assets/js/carousel.js"></script>
 
+    <!-- Copy-to-clipboard for .copy-code blocks -->
+    <script src="/assets/js/copy-code.js"></script>
+
     <!-- cookie banner, LF standard -->
     <script src="https://cmp.osano.com/16A0DbT9yDNIaQkvZ/31b1b91a-e0b6-47ea-bde2-7f2bd13dbe5c/osano.js?variant=one"></script>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,96 +16,96 @@
 {% endif %}
 
 <div class="whats-new-section">
-        <div class="whats-new-inner row">
-            <div class="col col-6">   
-                {% set release_section = get_section(path="download/releases/_index.md") %}
-                {% set releases = release_section.pages | reverse %}
-                
-                {% set_global active_releases = [] %}
-                {% for release in releases %}
-                    {% if release.extra.tag is not matching(".*-.*") %}
-                        {% set_global active_releases = active_releases | concat(with=release) %}
+    <div class="whats-new-inner row">
+        <div class="col col-6">
+            {# The newest stable release on each major.minor line, newest line first. #}
+            {% set release_section = get_section(path="download/releases/_index.md") %}
+            {% set_global release_lines = [] %}
+            {% set_global seen_lines = [] %}
+            {% for candidate in release_section.pages | sort(attribute="date") | reverse %}
+                {% if candidate.extra.tag is not matching(".*-.*") %}
+                    {% set candidate_line = candidate.extra.tag | split(pat=".") | slice(end=2) | join(sep=".") %}
+                    {% if candidate_line not in seen_lines %}
+                        {% set_global seen_lines = seen_lines | concat(with=candidate_line) %}
+                        {% set_global release_lines = release_lines | concat(with=candidate) %}
+                    {% endif %}
+                {% endif %}
+            {% endfor %}
+
+            {% set latest = release_lines | first %}
+            {% set latest_line = latest.extra.tag | split(pat=".") | slice(end=2) | join(sep=".") %}
+
+            <h3>Latest release</h3>
+            <div class="inner-card">
+                <p class="release-headline">
+                    <a href="/download/{{ latest_line }}/">Valkey {{ latest.extra.tag }}</a>
+                    <small>Released {{ latest.date | date(format="%B %-d, %Y") }}</small>
+                </p>
+
+                {# Highlights live in the /download/<line>/ page for the line. #}
+                {% set version_section = get_section(path="download/versions/_index.md") %}
+                {% for version_page in version_section.pages %}
+                    {% if version_page.extra.version == latest_line %}
+                        <div class="release-highlights">{{ version_page.content | safe }}</div>
+                        {% if version_page.extra.blog_url %}
+                            <a href="{{ version_page.extra.blog_url }}" class="link-readmore">{{ version_page.extra.blog_text }}</a>
+                        {% endif %}
                     {% endif %}
                 {% endfor %}
-                
-                {% set most_recent_release_page = active_releases | slice(end= 1) %}
-                {% set release_date = most_recent_release_page[0].date %}
-                {% set release = most_recent_release_page[0].extra %}
-                
-                {% set split_ver = release.tag | split(pat=".")%}
-                {% set_global major = split_ver | nth(n= 0) %}
-                
-                <h3> Version {{major}}.x.x </h3>
-                <div class="inner-card">
-                    {% include "includes/release.html" %}
-                </div>
-
-                <h3> Latest supported version of past releases</h3>
-                
-                <div class="inner-card">
-                    {% for older_release in active_releases %}
-                        {% set older_split_ver = older_release.extra.tag | split(pat=".")%}
-                        {% set older_major = older_split_ver | nth(n= 0) %}
-                        {% if older_major != major %}
-                            {% set_global major = older_major %}
-                            {% set release = older_release.extra %}
-                            <h4> Version {{major}}.x.x </h4>
-                            {% include "includes/release.html" %}
-                        {% endif %}
-                    {% endfor %}
-                </div>                   
-            </div>        
-            <div class="col col-3"> 
-                <h3>Performance</h3>
-                <div class="homepage-performance-section">
-                    {% set perf = load_data(path="_data/perf.toml") %}
-                    {% for perf_dashboard in perf.dashboards %}
-                    <div class="homepage-performance-card">
-                        <div class="homepage-performance-card-content">
-                            <h4><a href="{{ perf_dashboard.link }}">{{ perf_dashboard.title | markdown | safe }}</a></h4>
-                            {{ perf_dashboard.description | markdown | safe }}
-                            <a href="{{  perf_dashboard.link }}" class="view-dashboard">Explore</a>
-                        </div>
-
-                    </div>
-                    {% endfor %}
-                </div>
-                
             </div>
-            <div class="col col-3">   
-                <h3>Latest Blog Posts</h3>
-                <div class="homepage-blog-section">
-                    {% set blog_post_section = get_section(path="blog/_index.md") %}
-                    {% set blog_posts = blog_post_section.pages | slice(end=2) %}
-                    {% for post in blog_posts %}
-                        <div class="homepage-blog-card">
-                            <div class="homepage-blog-card-content">
-                                <h4 class="homepage-blog-card-title"><a href="{{ post.permalink }}">{{ post.title }}</a></h4>
-                                <p class="homepage-blog-card-description">{{ post.description }}</p>
-                                <a href="{{ post.permalink }}" class="homepage-blog-card-readmore">Read More</a>
-                            </div>
-                        </div>
+
+            <h3>Latest supported version of past releases</h3>
+            <div class="inner-card">
+                <ul class="list-links-small release-links">
+                    {% for older_release in release_lines | slice(start=1) %}
+                        {% set older_line = older_release.extra.tag | split(pat=".") | slice(end=2) | join(sep=".") %}
+                        <li>
+                            <a href="/download/{{ older_line }}/">Valkey {{ older_release.extra.tag }}</a>
+                            <small>Released {{ older_release.date | date(format="%B %-d, %Y") }}</small>
+                        </li>
                     {% endfor %}
-                </div>
-
-
-
-                {% if section.extra and section.extra.sidebar %}
-                    {% for sidebar_category in section.extra.sidebar %}
-                        <h3>{{sidebar_category.title}}</h3>
-                        <div class="inner-card">
-                            <ul class="list-links-small">
-                                {% for link in sidebar_category.links %}
-                                <li><a href="{{ link.url }}">{{ link.title}}</a></li>
-                                {% endfor %}
-                            </ul>
-                            {% if sidebar_category.more %} 
-                                <a href="{{ sidebar_category.more.url }}" class="link-readmore">{{sidebar_category.more.title}}</a> 
-                            {% endif %}
+                </ul>
+                <a href="/download/releases/" class="link-readmore">All releases</a>
+            </div>
+        </div>
+        <div class="col col-6">
+            <h3>Latest Blog Posts</h3>
+            <div class="homepage-blog-section">
+                {% set blog_post_section = get_section(path="blog/_index.md") %}
+                {% set blog_posts = blog_post_section.pages | slice(end=section.extra.latest_blog_posts) %}
+                {% for post in blog_posts %}
+                    {# The whole card is the link, so there is no separate call to action. #}
+                    <a class="homepage-blog-card" href="{{ post.permalink }}">
+                        {% if post.extra.featured_image %}
+                            {# Decorative: the card link is already named by the title and description. #}
+                            <img src="{{ post.extra.featured_image }}" alt="" class="homepage-blog-card-image" />
+                        {% else %}
+                            <div class="homepage-blog-card-image-placeholder"></div>
+                        {% endif %}
+                        <div class="homepage-blog-card-content">
+                            <h4 class="homepage-blog-card-title">{{ post.title }}</h4>
+                            <p class="homepage-blog-card-description">{{ post.description }}</p>
                         </div>
-                    {% endfor %}
-                {% endif %}
-            </div>        
+                    </a>
+                {% endfor %}
+            </div>
+
+            {% if section.extra and section.extra.sidebar %}
+                {% for sidebar_category in section.extra.sidebar %}
+                    <h3>{{sidebar_category.title}}</h3>
+                    <div class="inner-card">
+                        <ul class="list-links-small">
+                            {% for link in sidebar_category.links %}
+                            <li><a href="{{ link.url }}">{{ link.title}}</a></li>
+                            {% endfor %}
+                        </ul>
+                        {% if sidebar_category.more %}
+                            <a href="{{ sidebar_category.more.url }}" class="link-readmore">{{sidebar_category.more.title}}</a>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            {% endif %}
+        </div>
     </div>
 </div>
 
@@ -122,18 +122,21 @@
                 <div class="documentation-card">
                     <h3>{{ card.title }}</h3>
                     <p>{{ card.description }}</p>
-                    {% if card.features %}
-                    <ul>
-                        {% for feature in card.features %}
-                        <li>{{ feature }}</li>
-                        {% endfor %}
-                    </ul>
-                    {% endif %}
                     <a class="btn" href="{{ card.button_url }}">{{ card.button_text }}</a>
                 </div>
             </div>
             {% endfor %}
         {% endif %}
+        {% set perf = load_data(path="_data/perf.toml") %}
+        {% for perf_dashboard in perf.dashboards %}
+        <div class="col col-3">
+            <div class="documentation-card">
+                <h3>{{ perf_dashboard.title | markdown(inline=true) | safe }}</h3>
+                <p>{{ perf_dashboard.description | markdown(inline=true) | safe }}</p>
+                <a class="btn" href="{{ perf_dashboard.link }}">{{ perf_dashboard.button_text }}</a>
+            </div>
+        </div>
+        {% endfor %}
     </div>
 </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,23 +35,22 @@
             {% set latest = release_lines | first %}
             {% set latest_line = latest.extra.tag | split(pat=".") | slice(end=2) | join(sep=".") %}
 
+            {# Highlights and the line URL both come from the /download/<line>/ page.
+               get_page fails the build if a release ships without its line page. #}
+            {% set latest_slug = latest_line | replace(from=".", to="-") %}
+            {% set latest_line_page = get_page(path="download/versions/" ~ latest_slug ~ ".md") %}
+
             <h3>Latest release</h3>
             <div class="inner-card">
                 <p class="release-headline">
-                    <a href="/download/{{ latest_line }}/">Valkey {{ latest.extra.tag }}</a>
+                    <a href="{{ latest_line_page.permalink }}">Valkey {{ latest.extra.tag }}</a>
                     <small>Released {{ latest.date | date(format="%B %-d, %Y") }}</small>
                 </p>
 
-                {# Highlights live in the /download/<line>/ page for the line. #}
-                {% set version_section = get_section(path="download/versions/_index.md") %}
-                {% for version_page in version_section.pages %}
-                    {% if version_page.extra.version == latest_line %}
-                        <div class="release-highlights">{{ version_page.content | safe }}</div>
-                        {% if version_page.extra.blog_url %}
-                            <a href="{{ version_page.extra.blog_url }}" class="link-readmore">{{ version_page.extra.blog_text }}</a>
-                        {% endif %}
-                    {% endif %}
-                {% endfor %}
+                <div class="release-highlights">{{ latest_line_page.content | safe }}</div>
+                {% if latest_line_page.extra.blog_url %}
+                    <a href="{{ latest_line_page.extra.blog_url }}" class="link-readmore">{{ latest_line_page.extra.blog_text }}</a>
+                {% endif %}
             </div>
 
             <h3>Latest supported version of past releases</h3>
@@ -59,8 +58,10 @@
                 <ul class="list-links-small release-links">
                     {% for older_release in release_lines | slice(start=1) %}
                         {% set older_line = older_release.extra.tag | split(pat=".") | slice(end=2) | join(sep=".") %}
+                        {% set older_slug = older_line | replace(from=".", to="-") %}
+                        {% set older_line_page = get_page(path="download/versions/" ~ older_slug ~ ".md") %}
                         <li>
-                            <a href="/download/{{ older_line }}/">Valkey {{ older_release.extra.tag }}</a>
+                            <a href="{{ older_line_page.permalink }}">Valkey {{ older_release.extra.tag }}</a>
                             <small>Released {{ older_release.date | date(format="%B %-d, %Y") }}</small>
                         </li>
                     {% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -128,16 +128,6 @@
             </div>
             {% endfor %}
         {% endif %}
-        {% set perf = load_data(path="_data/perf.toml") %}
-        {% for perf_dashboard in perf.dashboards %}
-        <div class="col col-3">
-            <div class="documentation-card">
-                <h3>{{ perf_dashboard.title | markdown(inline=true) | safe }}</h3>
-                <p>{{ perf_dashboard.description | markdown(inline=true) | safe }}</p>
-                <a class="btn" href="{{ perf_dashboard.link }}">{{ perf_dashboard.button_text }}</a>
-            </div>
-        </div>
-        {% endfor %}
     </div>
 </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,20 +75,16 @@
                 {% set blog_post_section = get_section(path="blog/_index.md") %}
                 {% set blog_posts = blog_post_section.pages | slice(end=section.extra.latest_blog_posts) %}
                 {% for post in blog_posts %}
-                    {# The whole card is the link, so there is no separate call to action. #}
+                    {# The whole card is the link, so there is no separate call to action.
+                       Featured images are 16:9 decoration; a thumbnail this narrow could only
+                       show a crop of one, so the card is text with a colour accent instead. #}
                     <a class="homepage-blog-card" href="{{ post.permalink }}">
-                        {% if post.extra.featured_image %}
-                            {# Decorative: the card link is already named by the title and description. #}
-                            <img src="{{ post.extra.featured_image }}" alt="" class="homepage-blog-card-image" />
-                        {% else %}
-                            <div class="homepage-blog-card-image-placeholder"></div>
-                        {% endif %}
-                        <div class="homepage-blog-card-content">
-                            <h4 class="homepage-blog-card-title">{{ post.title }}</h4>
-                            <p class="homepage-blog-card-description">{{ post.description }}</p>
-                        </div>
+                        <h4 class="homepage-blog-card-title">{{ post.title }}</h4>
+                        <p class="homepage-blog-card-meta">{{ post.date | date(format="%B %-d, %Y") }}</p>
+                        <p class="homepage-blog-card-description">{{ post.description }}</p>
                     </a>
                 {% endfor %}
+                <a href="/blog/" class="link-readmore homepage-blog-more">All blog posts</a>
             </div>
 
             {% if section.extra and section.extra.sidebar %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,21 +70,23 @@
             </div>
         </div>
         <div class="col col-6">
-            <h3>Latest Blog Posts</h3>
+            <div class="homepage-blog-heading">
+                <h3>Latest Blog Posts</h3>
+                <a href="/blog/" class="homepage-blog-more">All blog posts</a>
+            </div>
             <div class="homepage-blog-section">
                 {% set blog_post_section = get_section(path="blog/_index.md") %}
                 {% set blog_posts = blog_post_section.pages | slice(end=section.extra.latest_blog_posts) %}
                 {% for post in blog_posts %}
                     {# The whole card is the link, so there is no separate call to action.
                        Featured images are 16:9 decoration; a thumbnail this narrow could only
-                       show a crop of one, so the card is text with a colour accent instead. #}
+                       show a crop of one, so the card is text instead. #}
                     <a class="homepage-blog-card" href="{{ post.permalink }}">
                         <h4 class="homepage-blog-card-title">{{ post.title }}</h4>
                         <p class="homepage-blog-card-meta">{{ post.date | date(format="%B %-d, %Y") }}</p>
                         <p class="homepage-blog-card-description">{{ post.description }}</p>
                     </a>
                 {% endfor %}
-                <a href="/blog/" class="link-readmore homepage-blog-more">All blog posts</a>
             </div>
 
             {% if section.extra and section.extra.sidebar %}

--- a/templates/macros/release.html
+++ b/templates/macros/release.html
@@ -1,4 +1,5 @@
-<strong>Release Date:</strong>  {{ release_date | date(format="%Y-%m-%d") }} <br/> 
+{% macro release_info(date, release) %}
+<strong>Release Date:</strong>  {{ date | date(format="%Y-%m-%d") }} <br/> 
 <strong>GitHub Release:</strong> <a href="https://github.com/valkey-io/valkey/releases/tag/{{release.tag}}">{{release.tag}}</a><br />
 <hr />
 
@@ -13,7 +14,19 @@
             {% endif %}
         {% endfor %}
     </ul>
-    <p>Example: <code>docker run --rm {{first_tag}}</code></p>
+    <p>Example:</p>
+    <div class="copy-code">
+        <pre><code>docker run --rm {{first_tag}}</code></pre>
+        <button type="button" class="copy-code-button" aria-label="Copy command to clipboard" title="Copy">
+            <svg class="copy-code-icon copy-code-icon-copy" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            <svg class="copy-code-icon copy-code-icon-done" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <polyline points="20 6 9 17 4 12" />
+            </svg>
+        </button>
+    </div>
     <hr />
 {% endfor %}
 {% if release.packages %}
@@ -39,3 +52,4 @@
     {% endfor %}
 {% endfor  %}
 {% endif %}
+{% endmacro release_info %}

--- a/templates/release-line.html
+++ b/templates/release-line.html
@@ -1,0 +1,46 @@
+{% extends "right-aside.html" %}
+{% import "macros/release.html" as release_macros %}
+
+{% block subhead_content %}
+<h1 class="page-title">Download Valkey {{ page.extra.version }}</h1>
+{% endblock subhead_content %}
+
+{% block main_content %}
+{% set line = page.extra.version %}
+
+{# Every stable release on this line, newest first. #}
+{% set release_section = get_section(path="download/releases/_index.md") %}
+{% set_global line_releases = [] %}
+{% for candidate in release_section.pages | sort(attribute="date") | reverse %}
+    {% if candidate.extra.tag is not matching(".*-.*") %}
+        {% set candidate_line = candidate.extra.tag | split(pat=".") | slice(end=2) | join(sep=".") %}
+        {% if candidate_line == line %}
+            {% set_global line_releases = line_releases | concat(with=candidate) %}
+        {% endif %}
+    {% endif %}
+{% endfor %}
+
+{% set latest = line_releases | first %}
+
+{% if page.content %}
+    <h2>Major features in {{ line }}:</h2>
+    <div class="release-highlights">{{ page.content | safe }}</div>
+    {% if page.extra.blog_url %}
+        <a href="{{ page.extra.blog_url }}" class="link-readmore">{{ page.extra.blog_text }}</a>
+    {% endif %}
+    <hr class="release-rule" />
+{% endif %}
+
+<h2>Get {{ latest.extra.tag }}</h2>
+{{ release_macros::release_info(date=latest.date, release=latest.extra) }}
+
+<h2>All {{ line }} releases</h2>
+<ul class="list-links-small release-links">
+    {% for line_release in line_releases %}
+    <li>
+        <a href="{{ line_release.permalink }}">Valkey {{ line_release.extra.tag }}</a>
+        <small>Released {{ line_release.date | date(format="%B %-d, %Y") }}</small>
+    </li>
+    {% endfor %}
+</ul>
+{% endblock main_content %}

--- a/templates/release-page.html
+++ b/templates/release-page.html
@@ -1,11 +1,9 @@
 {% extends "right-aside.html" %}
+{% import "macros/release.html" as release_macros %}
 
 {% block subhead_content%}
 <h1 class="page-title">Download Valkey {{page.title}}</h1>
 {% endblock subhead_content%}
 {% block main_content %}
-{% set release = page.extra %}
-{% set release_date = page.date %}
-
-{% include "includes/release.html" %}
+{{ release_macros::release_info(date=page.date, release=page.extra) }}
 {% endblock main_content %}

--- a/templates/release-section.html
+++ b/templates/release-section.html
@@ -9,7 +9,7 @@
 {% set_global release_lines = [] %}
 
 
-{% for release in section.pages | reverse %}
+{% for release in section.pages | sort(attribute="date") | reverse %}
     {% set split_ver = release.extra.tag | split(pat=".")%}
     {% set major = split_ver | nth(n= 0) %}
     {% set minor = split_ver | nth(n= 1) %}
@@ -23,7 +23,7 @@
 {% for line in release_lines_unique %}
     <h2>{{ line }}.x</h2>
     <ul>
-    {% for release in section.pages | reverse %}
+    {% for release in section.pages | sort(attribute="date") | reverse %}
         {% set split_ver = release.extra.tag | split(pat=".")%}
         {% set major = split_ver | nth(n= 0) %}
         {% set minor = split_ver | nth(n= 1) %}


### PR DESCRIPTION
This PR mostly attempts to tweak the main page so that there is less dead space and makes new versions cleaner. Added some text about the major new features + some links.



Performance got dropped down to one of the lower tiles. 

The blog cards lost their thumbnail. Every featured image is 1920x1080 and the 230px slot cropped them to roughly square, so each card showed an arbitrary slice of a gradient. Restoring the full 16:9 image is not an option either: at the column's ~620px width that is a 350px banner per card. The cards are text now, matching the release cards opposite, and a fourth post fills the height the images used to take. The blog index link moved up beside the heading.

See below for images
<details>

<img width="829" height="824" alt="image" src="https://github.com/user-attachments/assets/b077b977-12f6-4092-9dca-39feab37a1ff" />

<img width="1440" alt="Valkey homepage after the rework" src="https://raw.githubusercontent.com/madolson/valkey-io.github.io/pr-screenshots/pr662-home.png" />
</details>
